### PR TITLE
Bugfix/tmosley/fix cors address

### DIFF
--- a/apps/frontend/.env.dist
+++ b/apps/frontend/.env.dist
@@ -1,11 +1,11 @@
 VUE_APP_BLOG_URL=https://www.withobsrvr.com/blog
 VUE_APP_API_DOC_URL=https://www.withobsrvr.com/api-docs
-VUE_APP_BRAND_NAME=Stellarbeat
+VUE_APP_BRAND_NAME=Radar
 VUE_APP_BRAND_TAGLINE="Stellar Network Explorer"
-VUE_APP_BRAND_DESCRIPTION="Stellarbeat is a network explorer for the Stellar network. It provides a list of all nodes and organizations. It tracks various metrics and provides a history of changes. It also allows you to simulate different network conditions and topologies"
+VUE_APP_BRAND_DESCRIPTION="OBSRVR Radar is a network explorer for the Stellar network. It provides a list of all nodes and organizations. It tracks various metrics and provides a history of changes. It also allows you to simulate different network conditions and topologies"
 VUE_APP_BRAND_LOGO_SRC=logo.png
-VUE_APP_BRAND_LOGO_ALT=Stellarbeat
-VUE_APP_BRAND_EMAIL=info@stellarbeat.io
+VUE_APP_BRAND_LOGO_ALT=Radar
+VUE_APP_BRAND_EMAIL=hello@withobsrvr.com
 VUE_APP_PUBLIC_API_URL=http://localhost:3000
 VUE_APP_PUBLIC_ENABLE_NOTIFY=0
 VUE_APP_PUBLIC_ENABLE_HISTORY=1

--- a/apps/frontend/server.js
+++ b/apps/frontend/server.js
@@ -11,7 +11,7 @@ app.set("x-powered-by", false);
 let cacheTime = 86400000 * 7; //7 day cache for assets
 app.use(function (req, res, next) {
   res.setHeader("X-Frame-Options", "DENY"); //https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-  //res.setHeader('Content-Security-Policy', 'default-src \'self\' *.stellarbeat.io');//https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  //res.setHeader('Content-Security-Policy', 'default-src \'self\' *.withobsrvr.com');//https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
   res.setHeader("X-XSS-Protection", "1"); //https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
   res.setHeader("X-Content-Type-Options", "nosniff");
   if (

--- a/apps/frontend/src/components/consent.vue
+++ b/apps/frontend/src/components/consent.vue
@@ -10,7 +10,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 id="modal-1Label" class="modal-title">
-            Welcome to Stellarbeat.io!
+            Welcome to OBSRVR Radar!
           </h5>
         </div>
         <div class="modal-body">

--- a/packages/node-connector/readme.md
+++ b/packages/node-connector/readme.md
@@ -128,7 +128,7 @@ You can connect to any node with the example script:
 pnpm examples:connect ip port
 ```
 
-You can find ip/port of nodes on https://stellarbeat.io
+You can find ip/port of nodes on https://radar.withobsrvr.com
 
 The script connects to the node and logs the xdr stellar messages it receives to
 standard output. Using

--- a/packages/shared/test/history-archive-scan.test.ts
+++ b/packages/shared/test/history-archive-scan.test.ts
@@ -1,12 +1,12 @@
 import {HistoryArchiveScan} from "../src";
 
 it('should map from json', function () {
-    const url = 'https://history.stellarbeat.io';
+    const url = 'https://radar.withobsrvr.com/api/v1/history';
     const startDate = '2000/01/01';
     const endDate = '2000/01/02';
     const latestVerifiedLedger = 100
     const hasError = true;
-    const errorUrl = 'https://history.stellarbeat.io/gap';
+    const errorUrl = 'https://radar.withobsrvr.com/api/v1/history';
     const errorMessage = 'message';
     const isSlow = true;
 


### PR DESCRIPTION
This pull request updates branding and URLs across the codebase to reflect a rebranding from "Stellarbeat" to "OBSRVR Radar." The changes include updates to environment variables, user-facing text, documentation, and test files.

### Branding Updates:

* [`apps/frontend/.env.dist`](diffhunk://#diff-a373c5594dcd7506508eb00df48a91793005f7ab1eef12b4afd7a08af8ad77e3L3-R8): Updated `VUE_APP_BRAND_NAME`, `VUE_APP_BRAND_DESCRIPTION`, `VUE_APP_BRAND_LOGO_ALT`, and `VUE_APP_BRAND_EMAIL` to reflect the new branding as "Radar" under OBSRVR.
* [`apps/frontend/src/components/consent.vue`](diffhunk://#diff-bead1cf9132cc472300ce42d4c54a951ccd09de2656c721d47786f350593ef09L13-R13): Changed the welcome message title from "Welcome to Stellarbeat.io!" to "Welcome to OBSRVR Radar!"

### URL Updates:

* [`apps/frontend/server.js`](diffhunk://#diff-9e0d8aa428ad84582555a64ba5bab0f554e215e1092fed4959a7d223b3c5030eL14-R14): Updated the commented-out `Content-Security-Policy` header to use the new domain `*.withobsrvr.com` instead of `*.stellarbeat.io`.
* [`packages/node-connector/readme.md`](diffhunk://#diff-7dcc5634bce7ecfd07b9e30d1d959eda6126c56f7f32f68990a8baa794590caaL131-R131): Updated the documentation to point to the new node information URL `https://radar.withobsrvr.com` instead of `https://stellarbeat.io`.
* [`packages/shared/test/history-archive-scan.test.ts`](diffhunk://#diff-9c13fdc8c54288be89e1150a8f92621c9a8330faf7a77d2e66e56bcd88145936L4-R9): Updated test URLs to use the new API endpoint `https://radar.withobsrvr.com/api/v1/history` instead of the old `https://history.stellarbeat.io`.