### PR TITLE
add firewall

### DIFF
--- a/terraform/modules/app_platform/main.tf
+++ b/terraform/modules/app_platform/main.tf
@@ -17,8 +17,16 @@ resource "digitalocean_database_cluster" "radar_db" {
   node_count = 1
 }
 
-# Instead of using a firewall rule, we'll use the 'sslmode=no-verify' parameter in our connection string
-# and rely on DigitalOcean's internal network for security
+# Add trusted sources (firewall rules) to restrict database access
+resource "digitalocean_database_firewall" "radar_db_firewall" {
+  cluster_id = digitalocean_database_cluster.radar_db.id
+
+  # Explicitly add the entire App Platform app as a trusted source
+  rule {
+    type  = "app"
+    value = digitalocean_app.radar.id
+  }
+}
 
 # Create main database
 resource "digitalocean_database_db" "radar_db" {


### PR DESCRIPTION
This pull request introduces a security enhancement to the database configuration by replacing reliance on internal network security with explicit firewall rules. The most important change is the addition of a DigitalOcean database firewall to restrict access to trusted sources.

### Security improvements:

* [`terraform/modules/app_platform/main.tf`](diffhunk://#diff-9534b05168e7355750317bcd8f71c6e6e94d00c6b863a86cb3e306f0371f1a47L20-R29): Added a `digitalocean_database_firewall` resource to define explicit firewall rules for the `radar_db` database cluster. This includes adding the entire App Platform app as a trusted source to enhance security.