### PR TITLE
Update history scanner instance

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -213,6 +213,7 @@ jobs:
 
           # Infrastructure settings
           instance_size            = "${{ secrets.INSTANCE_SIZE || 'basic-xs' }}"
+          history_scanner_instance_size = "${{ secrets.HISTORY_SCANNER_INSTANCE_SIZE || 'basic-s' }}"
           frontend_instance_count  = 1
           backend_instance_count   = 1
           scanner_instance_count   = 1
@@ -375,6 +376,7 @@ jobs:
 
           # Infrastructure settings
           instance_size            = "${{ secrets.INSTANCE_SIZE || 'basic-xs' }}"
+          history_scanner_instance_size = "${{ secrets.HISTORY_SCANNER_INSTANCE_SIZE || 'professional-m' }}"
           frontend_instance_count  = 2
           backend_instance_count   = 1
           scanner_instance_count   = 1

--- a/terraform/environments/integration/main.tf
+++ b/terraform/environments/integration/main.tf
@@ -19,8 +19,9 @@ module "app_platform" {
   repo_url   = var.repo_url
   git_branch = "main"
 
-  environment   = "integration"
-  instance_size = "basic-xs"
+  environment                    = "integration"
+  instance_size                  = "basic-xs"
+  history_scanner_instance_size  = "basic-s"
 
   frontend_instance_count = 1
   backend_instance_count  = 1

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -22,8 +22,9 @@ module "app_platform" {
   git_branch                = var.git_branch
   database_version_postgres = var.database_version_postgres
 
-  environment   = "production"
-  instance_size = "professional-s"
+  environment                    = "production"
+  instance_size                  = "professional-s"
+  history_scanner_instance_size  = "professional-m"
 
   frontend_instance_count        = 2
   backend_instance_count         = 2

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -21,16 +21,16 @@ module "app_platform" {
   domain_name = var.domain_name
   git_branch  = var.git_branch
 
-  environment                    = "staging"
-  instance_size                  = "basic-xs"
-  history_scanner_instance_size  = "basic-s"
+  environment                   = "staging"
+  instance_size                 = "basic-xs"
+  history_scanner_instance_size = "basic-s"
 
   frontend_instance_count        = 1
   backend_instance_count         = 1
   testnet_backend_instance_count = 1
-  scanner_instance_count         = 0
+  scanner_instance_count         = 1
   testnet_scanner_instance_count = 0
-  history_scanner_instance_count = 0
+  history_scanner_instance_count = 1
   users_instance_count           = 1
 
   database_production = false

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -21,8 +21,9 @@ module "app_platform" {
   domain_name = var.domain_name
   git_branch  = var.git_branch
 
-  environment   = "staging"
-  instance_size = "basic-xs"
+  environment                    = "staging"
+  instance_size                  = "basic-xs"
+  history_scanner_instance_size  = "basic-s"
 
   frontend_instance_count        = 1
   backend_instance_count         = 1

--- a/terraform/modules/app_platform/main.tf
+++ b/terraform/modules/app_platform/main.tf
@@ -735,7 +735,7 @@ resource "digitalocean_app" "radar" {
       content {
         name               = "history-scanner"
         instance_count     = var.history_scanner_instance_count
-        instance_size_slug = var.history_scanner_instance_size != null ? var.history_scanner_instance_size : var.instance_size
+        instance_size_slug = coalesce(var.history_scanner_instance_size, var.instance_size)
 
         git {
           repo_clone_url = var.repo_url

--- a/terraform/modules/app_platform/main.tf
+++ b/terraform/modules/app_platform/main.tf
@@ -735,7 +735,7 @@ resource "digitalocean_app" "radar" {
       content {
         name               = "history-scanner"
         instance_count     = var.history_scanner_instance_count
-        instance_size_slug = var.instance_size
+        instance_size_slug = var.history_scanner_instance_size != null ? var.history_scanner_instance_size : var.instance_size
 
         git {
           repo_clone_url = var.repo_url

--- a/terraform/modules/app_platform/variables.tf
+++ b/terraform/modules/app_platform/variables.tf
@@ -38,7 +38,6 @@ variable "instance_size" {
 variable "history_scanner_instance_size" {
   description = "Instance size slug for history scanner"
   type        = string
-  default     = "professional-s"
 }
 
 variable "frontend_instance_count" {

--- a/terraform/modules/app_platform/variables.tf
+++ b/terraform/modules/app_platform/variables.tf
@@ -38,7 +38,7 @@ variable "instance_size" {
 variable "history_scanner_instance_size" {
   description = "Instance size slug for history scanner"
   type        = string
-  default     = null
+  default     = "professional-s"
 }
 
 variable "frontend_instance_count" {

--- a/terraform/modules/app_platform/variables.tf
+++ b/terraform/modules/app_platform/variables.tf
@@ -35,6 +35,12 @@ variable "instance_size" {
   type        = string
 }
 
+variable "history_scanner_instance_size" {
+  description = "Instance size slug for history scanner"
+  type        = string
+  default     = null
+}
+
 variable "frontend_instance_count" {
   description = "Number of frontend instances"
   type        = number


### PR DESCRIPTION
This pull request introduces changes to support configurable instance sizes for the "history scanner" component across different environments. The updates ensure flexibility in defining instance sizes specific to the history scanner, separate from the general instance size configuration.

### Infrastructure Configuration Updates:

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R216): Added `history_scanner_instance_size` configuration to workflows with default values for different environments (`basic-s` for standard environments and `professional-m` for production). [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R216) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R379)

* [`terraform/environments/integration/main.tf`](diffhunk://#diff-b730c2b78ef8f2744c59c01bbbf505a1135b45bb5921067e08bf94d77c7eb758R24): Introduced `history_scanner_instance_size` variable with a default value of `basic-s` for the integration environment.

* [`terraform/environments/production/main.tf`](diffhunk://#diff-22cad414f8ca436a2335474a4d2bbb8652df83f8983aebb903b80de603a071e4R27): Added `history_scanner_instance_size` variable with a default value of `professional-m` for the production environment.

* [`terraform/environments/staging/main.tf`](diffhunk://#diff-dcd44a5ed710d2ff4a1944ab687a98dc5def024f5d0ff235819a78fe6ce774d6R26): Defined `history_scanner_instance_size` variable with a default value of `basic-s` for the staging environment.

### Module Enhancements:

* [`terraform/modules/app_platform/main.tf`](diffhunk://#diff-9534b05168e7355750317bcd8f71c6e6e94d00c6b863a86cb3e306f0371f1a47L738-R738): Updated the `history-scanner` resource to use `history_scanner_instance_size` if defined, falling back to the general `instance_size` if not.

* [`terraform/modules/app_platform/variables.tf`](diffhunk://#diff-a1da45a6a6f2abb7a8cc11a12a6c264c3c091f63013ff561121be7be7423617fR38-R43): Added a new variable `history_scanner_instance_size` with a default value of `null` to enable optional configuration of the history scanner's instance size.