### PR TITLE
Update instances

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,8 +212,8 @@ jobs:
           user_service_password    = "${{ secrets.USER_SERVICE_PASSWORD || '' }}"
 
           # Infrastructure settings
-          instance_size            = "${{ secrets.INSTANCE_SIZE || 'basic-xs' }}"
-          history_scanner_instance_size = "${{ secrets.HISTORY_SCANNER_INSTANCE_SIZE || 'basic-s' }}"
+          instance_size            = "${{ secrets.INSTANCE_SIZE || 'apps-s-1vcpu-1gb' }}"
+          history_scanner_instance_size = "${{ secrets.HISTORY_SCANNER_INSTANCE_SIZE || 'apps-d-2vcpu-8gb' }}"
           frontend_instance_count  = 1
           backend_instance_count   = 1
           scanner_instance_count   = 1
@@ -375,8 +375,8 @@ jobs:
           user_service_password    = "${{ secrets.USER_SERVICE_PASSWORD || '' }}"
 
           # Infrastructure settings
-          instance_size            = "${{ secrets.INSTANCE_SIZE || 'basic-xs' }}"
-          history_scanner_instance_size = "${{ secrets.HISTORY_SCANNER_INSTANCE_SIZE || 'professional-m' }}"
+          instance_size            = "${{ secrets.INSTANCE_SIZE || 'apps-s-1vcpu-2gb' }}"
+          history_scanner_instance_size = "${{ secrets.HISTORY_SCANNER_INSTANCE_SIZE || 'apps-d-4vcpu-16gb' }}"
           frontend_instance_count  = 2
           backend_instance_count   = 1
           scanner_instance_count   = 1

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -23,8 +23,8 @@ module "app_platform" {
   database_version_postgres = var.database_version_postgres
 
   environment                    = "production"
-  instance_size                  = "professional-s"
-  history_scanner_instance_size  = "professional-m"
+  instance_size                  = "apps-s-1vcpu-2gb"
+  history_scanner_instance_size  = "apps-d-4vcpu-16gb"
 
   frontend_instance_count        = 2
   backend_instance_count         = 2

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -22,8 +22,8 @@ module "app_platform" {
   git_branch  = var.git_branch
 
   environment                   = "staging"
-  instance_size                 = "basic-xs"
-  history_scanner_instance_size = "basic-s"
+  instance_size                 = "apps-s-1vcpu-1gb"
+  history_scanner_instance_size = "apps-d-2vcpu-8gb"
 
   frontend_instance_count        = 1
   backend_instance_count         = 1


### PR DESCRIPTION
This pull request updates infrastructure configurations to improve performance and scalability across different environments. The changes primarily involve modifying instance sizes for various services in both CI/CD workflows and Terraform configurations.

### CI/CD Workflow Updates:
* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L215-R216): Updated `instance_size` and `history_scanner_instance_size` values for staging and production environments to use more performant specifications. Staging now uses `apps-s-1vcpu-1gb` and `apps-d-2vcpu-8gb`, while production uses `apps-s-1vcpu-2gb` and `apps-d-4vcpu-16gb`. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L215-R216) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L378-R379)

### Terraform Configuration Updates:
* [`terraform/environments/production/main.tf`](diffhunk://#diff-22cad414f8ca436a2335474a4d2bbb8652df83f8983aebb903b80de603a071e4L26-R27): Changed `instance_size` to `apps-s-1vcpu-2gb` and `history_scanner_instance_size` to `apps-d-4vcpu-16gb` for better resource allocation in the production environment.
* [`terraform/environments/staging/main.tf`](diffhunk://#diff-dcd44a5ed710d2ff4a1944ab687a98dc5def024f5d0ff235819a78fe6ce774d6L25-R26): Updated `instance_size` to `apps-s-1vcpu-1gb` and `history_scanner_instance_size` to `apps-d-2vcpu-8gb` to align with the staging environment's needs.