### PR TITLE
Add trust rank

### DIFF
--- a/apps/backend/src/core/infrastructure/database/migrations/1751570404901-trust-centrality-metrics.ts
+++ b/apps/backend/src/core/infrastructure/database/migrations/1751570404901-trust-centrality-metrics.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TrustCentralityMetrics1751570404901 implements MigrationInterface {
+	name = 'TrustCentralityMetrics1751570404901';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ADD "trustCentralityScore" decimal(10,8) DEFAULT 0`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ADD "pageRankScore" decimal(10,8) DEFAULT 0`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ADD "trustRank" integer DEFAULT 0`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ADD "lastTrustCalculation" timestamptz`
+		);
+
+		// Add indexes for performance
+		await queryRunner.query(
+			`CREATE INDEX "IDX_node_snap_shot_trust_centrality_score" ON "node_snap_shot" ("trustCentralityScore")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_node_snap_shot_page_rank_score" ON "node_snap_shot" ("pageRankScore")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_node_snap_shot_trust_rank" ON "node_snap_shot" ("trustRank")`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`DROP INDEX "IDX_node_snap_shot_trust_rank"`
+		);
+		await queryRunner.query(
+			`DROP INDEX "IDX_node_snap_shot_page_rank_score"`
+		);
+		await queryRunner.query(
+			`DROP INDEX "IDX_node_snap_shot_trust_centrality_score"`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" DROP COLUMN "lastTrustCalculation"`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" DROP COLUMN "trustRank"`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" DROP COLUMN "pageRankScore"`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" DROP COLUMN "trustCentralityScore"`
+		);
+	}
+}

--- a/apps/backend/src/core/infrastructure/database/migrations/1751577500000-fix-trust-metrics-precision.ts
+++ b/apps/backend/src/core/infrastructure/database/migrations/1751577500000-fix-trust-metrics-precision.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixTrustMetricsPrecision1751577500000 implements MigrationInterface {
+	name = 'FixTrustMetricsPrecision1751577500000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		// Update node_snap_shot table - change from decimal(10,8) to decimal(12,8) to allow values up to 9999.99999999
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ALTER COLUMN "trustCentralityScore" TYPE decimal(12,8)`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ALTER COLUMN "pageRankScore" TYPE decimal(12,8)`
+		);
+
+		// Update node_measurement_v2 table - change from decimal(10,8) to decimal(12,8)
+		await queryRunner.query(
+			`ALTER TABLE "node_measurement_v2" ALTER COLUMN "trustCentralityScore" TYPE decimal(12,8)`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_measurement_v2" ALTER COLUMN "pageRankScore" TYPE decimal(12,8)`
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		// Revert back to original precision - note this may cause data loss if values exceed the smaller precision
+		await queryRunner.query(
+			`ALTER TABLE "node_measurement_v2" ALTER COLUMN "pageRankScore" TYPE decimal(10,8)`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_measurement_v2" ALTER COLUMN "trustCentralityScore" TYPE decimal(10,8)`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ALTER COLUMN "pageRankScore" TYPE decimal(10,8)`
+		);
+		await queryRunner.query(
+			`ALTER TABLE "node_snap_shot" ALTER COLUMN "trustCentralityScore" TYPE decimal(10,8)`
+		);
+	}
+}

--- a/apps/backend/src/network-scan/domain/node/NodeMeasurement.ts
+++ b/apps/backend/src/network-scan/domain/node/NodeMeasurement.ts
@@ -46,6 +46,18 @@ export default class NodeMeasurement implements Measurement {
 	@Column('smallint', { default: null, name: 'lag', nullable: true })
 	private _lag: number | null = null;
 
+	@Column('decimal', { precision: 12, scale: 8, nullable: true, default: 0 })
+	trustCentralityScore: number = 0;
+
+	@Column('decimal', { precision: 12, scale: 8, nullable: true, default: 0 })
+	pageRankScore: number = 0;
+
+	@Column('integer', { nullable: true, default: 0 })
+	trustRank: number = 0;
+
+	@Column('timestamptz', { nullable: true })
+	lastTrustCalculation: Date | null = null;
+
 	//todo: remove Node constructor parameter and make ValueObject
 	constructor(time: Date, node: Node) {
 		this.time = time;

--- a/apps/backend/src/network-scan/domain/node/NodeSnapShot.ts
+++ b/apps/backend/src/network-scan/domain/node/NodeSnapShot.ts
@@ -69,6 +69,18 @@ export default class NodeSnapShot extends Snapshot {
 	@Column('timestamptz', { nullable: true })
 	public lastIpChange: Date | null = null;
 
+	@Column('decimal', { precision: 12, scale: 8, nullable: true, default: 0 })
+	public trustCentralityScore: number = 0;
+
+	@Column('decimal', { precision: 12, scale: 8, nullable: true, default: 0 })
+	public pageRankScore: number = 0;
+
+	@Column('integer', { nullable: true, default: 0 })
+	public trustRank: number = 0;
+
+	@Column('timestamptz', { nullable: true })
+	public lastTrustCalculation: Date | null = null;
+
 	//typeOrm does not fill in constructor parameters. should be fixed in a later version.
 	constructor(startDate: Date, ip: string, port: number) {
 		super(startDate);
@@ -139,6 +151,10 @@ export default class NodeSnapShot extends Snapshot {
 		copy.nodeDetails = this.nodeDetails;
 		copy.quorumSet = this.quorumSet;
 		copy.geoData = this.geoData;
+		copy.trustCentralityScore = this.trustCentralityScore;
+		copy.pageRankScore = this.pageRankScore;
+		copy.trustRank = this.trustRank;
+		copy.lastTrustCalculation = this.lastTrustCalculation;
 
 		return copy;
 	}

--- a/apps/backend/src/network-scan/domain/node/scan/NodeIndexer.ts
+++ b/apps/backend/src/network-scan/domain/node/scan/NodeIndexer.ts
@@ -12,6 +12,7 @@ export class NodeIndexer {
 	) {
 		return NodeIndex.calculateIndexes(
 			nodes.map((node) => {
+				const latestMeasurement = node.latestMeasurement();
 				return {
 					publicKey: node.publicKey.value,
 					stellarCoreVersion: node.versionStr ?? 'unknown',
@@ -24,9 +25,10 @@ export class NodeIndexer {
 						measurement30DayAverages.find(
 							(measurement) => measurement.publicKey === node.publicKey.value
 						)?.activeAvg ?? 0,
-					isValidating: node.latestMeasurement()?.isValidating ?? false,
+					isValidating: latestMeasurement?.isValidating ?? false,
 					hasUpToDateHistoryArchive:
-						node.latestMeasurement()?.isFullValidator ?? false
+						latestMeasurement?.isFullValidator ?? false,
+					trustCentralityScore: latestMeasurement?.trustCentralityScore
 				};
 			}),
 			TrustGraphFactory.create(nodes),

--- a/apps/backend/src/network-scan/domain/node/scan/NodeScannerIndexerStep.ts
+++ b/apps/backend/src/network-scan/domain/node/scan/NodeScannerIndexerStep.ts
@@ -1,17 +1,48 @@
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { StellarCoreVersion } from '../../network/StellarCoreVersion';
 import { NodeMeasurementAverage } from '../NodeMeasurementAverage';
 import { NodeScan } from './NodeScan';
 import { NodeIndexer } from './NodeIndexer';
+import { TrustRankCalculator, ITrustRankCalculator } from '../../trust/TrustRankCalculator';
+import { TrustGraphFactory } from './TrustGraphFactory';
+import { NodeTrustData } from '../../trust/TrustMetrics';
 import 'reflect-metadata';
 
 @injectable()
 export class NodeScannerIndexerStep {
+	constructor(
+		@inject(TrustRankCalculator) private trustRankCalculator: ITrustRankCalculator
+	) {}
+
 	public execute(
 		nodeScan: NodeScan,
 		measurement30DayAverages: NodeMeasurementAverage[],
 		stellarCoreVersion: StellarCoreVersion
 	): void {
+		// Calculate trust metrics for all nodes
+		const trustGraph = TrustGraphFactory.create(nodeScan.nodes);
+		const nodeData = this.buildNodeTrustData(nodeScan.nodes);
+		
+		const trustResult = this.trustRankCalculator.calculateTrustMetrics(
+			trustGraph,
+			nodeData
+		);
+
+		// Update nodes with trust metrics
+		nodeScan.nodes.forEach(node => {
+			const trustMetrics = trustResult.trustMetrics.get(node.publicKey.value);
+			if (trustMetrics) {
+				const latestMeasurement = node.latestMeasurement();
+				if (latestMeasurement) {
+					latestMeasurement.trustCentralityScore = trustMetrics.trustCentralityScore;
+					latestMeasurement.pageRankScore = trustMetrics.pageRankScore;
+					latestMeasurement.trustRank = trustMetrics.trustRank;
+					latestMeasurement.lastTrustCalculation = trustMetrics.lastTrustCalculation;
+				}
+			}
+		});
+
+		// Calculate indexes using existing logic
 		nodeScan.updateIndexes(
 			NodeIndexer.calculateIndexes(
 				nodeScan.nodes,
@@ -19,5 +50,21 @@ export class NodeScannerIndexerStep {
 				stellarCoreVersion
 			)
 		);
+	}
+
+	private buildNodeTrustData(nodes: any[]): Map<string, NodeTrustData> {
+		const nodeData = new Map<string, NodeTrustData>();
+		
+		nodes.forEach(node => {
+			const organizationId = node.organizationId ? node.organizationId.value : null;
+			const latestMeasurement = node.latestMeasurement();
+			
+			nodeData.set(node.publicKey.value, {
+				organizationId,
+				isValidator: latestMeasurement?.isValidating || false
+			});
+		});
+
+		return nodeData;
 	}
 }

--- a/apps/backend/src/network-scan/domain/node/scan/node-index/node-index.ts
+++ b/apps/backend/src/network-scan/domain/node/scan/node-index/node-index.ts
@@ -14,6 +14,7 @@ export interface IndexNode {
 	stellarCoreVersion: string;
 	dateDiscovered: Date;
 	validating30DaysPercentage: number;
+	trustCentralityScore?: number;
 }
 
 export class NodeIndex {
@@ -25,12 +26,17 @@ export class NodeIndex {
 		//index two digits after comma
 		const result = new Map<string, number>();
 		nodes.forEach((node) => {
+			// Use pre-calculated trust score if available, otherwise fall back to old calculation
+			const trustScore = node.trustCentralityScore !== undefined 
+				? node.trustCentralityScore / 100  // Convert 0-100 scale to 0-1 scale
+				: TrustIndex.get(node.publicKey, trustGraph);
+
 			const indexRaw =
 				(TypeIndex.get(node.hasUpToDateHistoryArchive, node.isValidating) +
 					ActiveIndex.get(node.isActive30DaysPercentage) +
 					ValidatingIndex.get(node.validating30DaysPercentage) +
 					VersionIndex.get(node.stellarCoreVersion, currentStellarCoreVersion) +
-					TrustIndex.get(node.publicKey, trustGraph) +
+					trustScore +
 					AgeIndex.get(node.dateDiscovered)) /
 				6;
 

--- a/apps/backend/src/network-scan/domain/trust/PageRankAlgorithm.ts
+++ b/apps/backend/src/network-scan/domain/trust/PageRankAlgorithm.ts
@@ -1,0 +1,152 @@
+import { TrustGraph, Vertex } from 'shared';
+import { PageRankConfiguration } from './TrustMetrics';
+
+export class PageRankAlgorithm {
+	/**
+	 * Calculates PageRank scores for vertices in a trust graph
+	 * @param trustGraph The trust graph to analyze
+	 * @param config PageRank algorithm configuration
+	 * @returns Map of vertex keys to their PageRank scores
+	 */
+	public calculatePageRank(
+		trustGraph: TrustGraph,
+		config: PageRankConfiguration
+	): { scores: Map<string, number>; convergenceAchieved: boolean; iterationsUsed: number } {
+		const vertices = Array.from(trustGraph.vertices.values());
+		const numVertices = vertices.length;
+
+		if (numVertices === 0) {
+			return {
+				scores: new Map(),
+				convergenceAchieved: true,
+				iterationsUsed: 0
+			};
+		}
+
+		// Initialize PageRank scores
+		const scores = new Map<string, number>();
+		const newScores = new Map<string, number>();
+		const initialScore = 1.0 / numVertices;
+
+		vertices.forEach((vertex: Vertex) => {
+			scores.set(vertex.key, initialScore);
+			newScores.set(vertex.key, 0);
+		});
+
+		let convergenceAchieved = false;
+		let iteration = 0;
+
+		for (iteration = 0; iteration < config.maxIterations; iteration++) {
+			// Reset new scores
+			vertices.forEach((vertex: Vertex) => {
+				newScores.set(vertex.key, 0);
+			});
+
+			// Calculate new scores
+			vertices.forEach((vertex: Vertex) => {
+				const parents = trustGraph.getParents(vertex);
+				let incomingScore = 0;
+
+				parents.forEach((parent: Vertex) => {
+					const parentScore = scores.get(parent.key) || 0;
+					const parentOutDegree = trustGraph.getChildren(parent).size;
+					
+					if (parentOutDegree > 0) {
+						incomingScore += parentScore / parentOutDegree;
+					}
+				});
+
+				const newScore = (1 - config.dampingFactor) / numVertices + 
+					config.dampingFactor * incomingScore;
+				newScores.set(vertex.key, newScore);
+			});
+
+			// Check for convergence
+			let maxDifference = 0;
+			vertices.forEach((vertex: Vertex) => {
+				const oldScore = scores.get(vertex.key) || 0;
+				const newScore = newScores.get(vertex.key) || 0;
+				const difference = Math.abs(newScore - oldScore);
+				maxDifference = Math.max(maxDifference, difference);
+			});
+
+			// Update scores
+			vertices.forEach((vertex: Vertex) => {
+				scores.set(vertex.key, newScores.get(vertex.key) || 0);
+			});
+
+			if (maxDifference < config.convergenceThreshold) {
+				convergenceAchieved = true;
+				break;
+			}
+		}
+
+		return {
+			scores,
+			convergenceAchieved,
+			iterationsUsed: iteration + 1
+		};
+	}
+
+	/**
+	 * Normalizes PageRank scores to a 0-100 scale
+	 * @param scores Raw PageRank scores
+	 * @returns Normalized scores
+	 */
+	public normalizeScores(scores: Map<string, number>): Map<string, number> {
+		const normalizedScores = new Map<string, number>();
+		
+		if (scores.size === 0) {
+			return normalizedScores;
+		}
+
+		const maxScore = Math.max(...Array.from(scores.values()));
+		const minScore = Math.min(...Array.from(scores.values()));
+		const range = maxScore - minScore;
+
+		if (range === 0) {
+			// All scores are the same
+			scores.forEach((_, key) => {
+				normalizedScores.set(key, 50); // Set to middle value
+			});
+		} else {
+			scores.forEach((score, key) => {
+				const normalized = ((score - minScore) / range) * 100;
+				normalizedScores.set(key, normalized);
+			});
+		}
+
+		return normalizedScores;
+	}
+
+	/**
+	 * Creates rankings from PageRank scores (1 = highest score)
+	 * @param scores PageRank scores
+	 * @returns Map of vertex keys to their rank
+	 */
+	public createRankings(scores: Map<string, number>): Map<string, number> {
+		const rankings = new Map<string, number>();
+		
+		// Sort vertices by score (descending)
+		const sortedEntries = Array.from(scores.entries()).sort((a, b) => b[1] - a[1]);
+		
+		// Assign rankings (handle ties)
+		let currentRank = 1;
+		let previousScore: number | null = null;
+		let sameRankCount = 0;
+
+		sortedEntries.forEach(([key, score]) => {
+			if (previousScore !== null && score < previousScore) {
+				currentRank += sameRankCount;
+				sameRankCount = 1;
+			} else {
+				sameRankCount++;
+			}
+			
+			rankings.set(key, currentRank);
+			previousScore = score;
+		});
+
+		return rankings;
+	}
+}

--- a/apps/backend/src/network-scan/domain/trust/TrustMetrics.ts
+++ b/apps/backend/src/network-scan/domain/trust/TrustMetrics.ts
@@ -1,0 +1,30 @@
+export interface TrustMetrics {
+	trustCentralityScore: number;
+	pageRankScore: number;
+	trustRank: number;
+	lastTrustCalculation: Date;
+}
+
+export interface PageRankConfiguration {
+	dampingFactor: number;
+	maxIterations: number;
+	convergenceThreshold: number;
+}
+
+export const DEFAULT_PAGERANK_CONFIG: PageRankConfiguration = {
+	dampingFactor: 0.85,
+	maxIterations: 100,
+	convergenceThreshold: 1e-6
+};
+
+export interface NodeTrustData {
+	organizationId?: string | null;
+	isValidator: boolean;
+}
+
+export interface TrustCalculationResult {
+	trustMetrics: Map<string, TrustMetrics>;
+	convergenceAchieved: boolean;
+	iterationsUsed: number;
+	calculationTimestamp: Date;
+}

--- a/apps/backend/src/network-scan/domain/trust/TrustRankCalculator.ts
+++ b/apps/backend/src/network-scan/domain/trust/TrustRankCalculator.ts
@@ -1,0 +1,176 @@
+import { TrustGraph, PublicKey } from 'shared';
+import { PageRankAlgorithm } from './PageRankAlgorithm';
+import {
+	TrustMetrics,
+	PageRankConfiguration,
+	DEFAULT_PAGERANK_CONFIG,
+	NodeTrustData,
+	TrustCalculationResult
+} from './TrustMetrics';
+import { injectable } from 'inversify';
+import 'reflect-metadata';
+
+export interface ITrustRankCalculator {
+	calculateTrustMetrics(
+		trustGraph: TrustGraph,
+		nodeData: Map<PublicKey, NodeTrustData>,
+		config?: PageRankConfiguration
+	): TrustCalculationResult;
+}
+
+@injectable()
+export class TrustRankCalculator implements ITrustRankCalculator {
+	private readonly pageRankAlgorithm: PageRankAlgorithm;
+
+	constructor() {
+		this.pageRankAlgorithm = new PageRankAlgorithm();
+	}
+
+	/**
+	 * Calculates comprehensive trust metrics for all nodes in the network
+	 * @param trustGraph The trust relationship graph
+	 * @param nodeData Additional node metadata
+	 * @param config PageRank algorithm configuration
+	 * @returns Complete trust calculation results
+	 */
+	public calculateTrustMetrics(
+		trustGraph: TrustGraph,
+		nodeData: Map<PublicKey, NodeTrustData>,
+		config: PageRankConfiguration = DEFAULT_PAGERANK_CONFIG
+	): TrustCalculationResult {
+		const calculationTimestamp = new Date();
+
+		// Calculate base PageRank scores
+		const pageRankResult = this.pageRankAlgorithm.calculatePageRank(trustGraph, config);
+		
+		// Normalize PageRank scores to 0-100 scale
+		const normalizedPageRankScores = this.pageRankAlgorithm.normalizeScores(pageRankResult.scores);
+		
+		// Calculate trust centrality scores (enhanced PageRank with organizational diversity)
+		const trustCentralityScores = this.calculateTrustCentralityScores(
+			trustGraph,
+			normalizedPageRankScores,
+			nodeData
+		);
+		
+		// Create rankings based on trust centrality
+		const trustRankings = this.pageRankAlgorithm.createRankings(trustCentralityScores);
+
+		// Build final trust metrics map
+		const trustMetrics = new Map<string, TrustMetrics>();
+		
+		Array.from(trustGraph.vertices.keys()).forEach((publicKey: PublicKey) => {
+			const pageRankScore = normalizedPageRankScores.get(publicKey) || 0;
+			const trustCentralityScore = trustCentralityScores.get(publicKey) || 0;
+			const trustRank = trustRankings.get(publicKey) || Number.MAX_SAFE_INTEGER;
+
+			trustMetrics.set(publicKey, {
+				trustCentralityScore,
+				pageRankScore,
+				trustRank,
+				lastTrustCalculation: calculationTimestamp
+			});
+		});
+
+		return {
+			trustMetrics,
+			convergenceAchieved: pageRankResult.convergenceAchieved,
+			iterationsUsed: pageRankResult.iterationsUsed,
+			calculationTimestamp
+		};
+	}
+
+	/**
+	 * Calculates trust centrality scores by enhancing PageRank with organizational diversity
+	 * @param trustGraph The trust relationship graph
+	 * @param pageRankScores Base PageRank scores (0-100)
+	 * @param nodeData Node metadata including organization information
+	 * @returns Enhanced trust centrality scores
+	 */
+	private calculateTrustCentralityScores(
+		trustGraph: TrustGraph,
+		pageRankScores: Map<string, number>,
+		nodeData: Map<PublicKey, NodeTrustData>
+	): Map<string, number> {
+		const trustCentralityScores = new Map<string, number>();
+
+		Array.from(trustGraph.vertices.keys()).forEach((publicKey: PublicKey) => {
+			const basePageRankScore = pageRankScores.get(publicKey) || 0;
+			const node = nodeData.get(publicKey);
+			
+			if (!node) {
+				trustCentralityScores.set(publicKey, basePageRankScore);
+				return;
+			}
+
+			// Calculate organizational diversity bonus
+			const organizationalDiversityBonus = this.calculateOrganizationalDiversityBonus(
+				trustGraph,
+				publicKey,
+				nodeData
+			);
+
+			// Calculate validator bonus (validators are more important for consensus)
+			const validatorBonus = node.isValidator ? 1.1 : 1.0;
+
+			// Apply bonuses to base PageRank score
+			const enhancedScore = basePageRankScore * organizationalDiversityBonus * validatorBonus;
+			
+			// Ensure score stays within 0-100 bounds
+			const boundedScore = Math.min(100, Math.max(0, enhancedScore));
+			
+			trustCentralityScores.set(publicKey, boundedScore);
+		});
+
+		// Re-normalize to ensure proper 0-100 distribution
+		return this.pageRankAlgorithm.normalizeScores(trustCentralityScores);
+	}
+
+	/**
+	 * Calculates a bonus multiplier based on organizational diversity of incoming trust
+	 * @param trustGraph The trust relationship graph
+	 * @param publicKey The node to analyze
+	 * @param nodeData Node metadata
+	 * @returns Multiplier between 1.0 and 2.0 based on organizational diversity
+	 */
+	private calculateOrganizationalDiversityBonus(
+		trustGraph: TrustGraph,
+		publicKey: PublicKey,
+		nodeData: Map<PublicKey, NodeTrustData>
+	): number {
+		const vertex = trustGraph.getVertex(publicKey);
+		if (!vertex) {
+			return 1.0;
+		}
+
+		const parents = trustGraph.getParents(vertex);
+		const uniqueOrganizations = new Set<string>();
+		let totalIncomingTrust = 0;
+
+		// Collect organizations that trust this node
+		parents.forEach((parent: any) => {
+			const parentData = nodeData.get(parent.key);
+			if (parentData?.organizationId) {
+				uniqueOrganizations.add(parentData.organizationId);
+			}
+			totalIncomingTrust++;
+		});
+
+		// If no incoming trust, return base multiplier
+		if (totalIncomingTrust === 0) {
+			return 1.0;
+		}
+
+		// Calculate diversity ratio (unique orgs / total incoming trust)
+		const diversityRatio = uniqueOrganizations.size / totalIncomingTrust;
+		
+		// Calculate bonus based on both number of unique organizations and diversity ratio
+		const organizationCountBonus = Math.min(uniqueOrganizations.size / 5, 1.0); // Cap at 5 orgs
+		const diversityRatioBonus = diversityRatio;
+		
+		// Combine bonuses: 1.0 (base) + up to 0.5 (org count) + up to 0.5 (diversity ratio)
+		const totalBonus = 1.0 + (organizationCountBonus * 0.5) + (diversityRatioBonus * 0.5);
+		
+		return Math.min(2.0, totalBonus); // Cap at 2.0x multiplier
+	}
+}

--- a/apps/backend/src/network-scan/domain/trust/__tests__/PageRankAlgorithm.test.ts
+++ b/apps/backend/src/network-scan/domain/trust/__tests__/PageRankAlgorithm.test.ts
@@ -1,0 +1,277 @@
+import { PageRankAlgorithm } from '../PageRankAlgorithm';
+import { TrustGraph, Vertex } from 'shared';
+import { DEFAULT_PAGERANK_CONFIG, PageRankConfiguration } from '../TrustMetrics';
+
+describe('PageRankAlgorithm', () => {
+	let pageRankAlgorithm: PageRankAlgorithm;
+
+	beforeEach(() => {
+		pageRankAlgorithm = new PageRankAlgorithm();
+	});
+
+	describe('calculatePageRank', () => {
+		it('should calculate PageRank for a simple graph', () => {
+			// Arrange
+			const graph = createSimpleGraph();
+			
+			// Act
+			const result = pageRankAlgorithm.calculatePageRank(graph, DEFAULT_PAGERANK_CONFIG);
+			
+			// Assert
+			expect(result.scores.size).toBe(3);
+			expect(result.convergenceAchieved).toBe(true);
+			expect(result.iterationsUsed).toBeGreaterThan(0);
+			
+			// Verify scores are positive and sum approximately to 1
+			const scores = Array.from(result.scores.values());
+			scores.forEach(score => expect(score).toBeGreaterThan(0));
+			
+			const sum = scores.reduce((a, b) => a + b, 0);
+			expect(sum).toBeCloseTo(1, 2);
+		});
+
+		it('should handle empty graph', () => {
+			// Arrange
+			const graph = new TrustGraph();
+			
+			// Act
+			const result = pageRankAlgorithm.calculatePageRank(graph, DEFAULT_PAGERANK_CONFIG);
+			
+			// Assert
+			expect(result.scores.size).toBe(0);
+			expect(result.convergenceAchieved).toBe(true);
+			expect(result.iterationsUsed).toBe(0);
+		});
+
+		it('should handle single node graph', () => {
+			// Arrange
+			const graph = new TrustGraph();
+			const vertex = new Vertex('single');
+			graph.addVertex(vertex);
+			
+			// Act
+			const result = pageRankAlgorithm.calculatePageRank(graph, DEFAULT_PAGERANK_CONFIG);
+			
+			// Assert
+			expect(result.scores.size).toBe(1);
+			expect(result.scores.get('single')).toBe(1);
+			expect(result.convergenceAchieved).toBe(true);
+		});
+
+		it('should converge faster with higher damping factor', () => {
+			// Arrange
+			const graph = createComplexGraph();
+			const lowDampingConfig: PageRankConfiguration = {
+				...DEFAULT_PAGERANK_CONFIG,
+				dampingFactor: 0.1
+			};
+			const highDampingConfig: PageRankConfiguration = {
+				...DEFAULT_PAGERANK_CONFIG,
+				dampingFactor: 0.9
+			};
+			
+			// Act
+			const lowDampingResult = pageRankAlgorithm.calculatePageRank(graph, lowDampingConfig);
+			const highDampingResult = pageRankAlgorithm.calculatePageRank(graph, highDampingConfig);
+			
+			// Assert
+			expect(lowDampingResult.iterationsUsed).toBeLessThanOrEqual(highDampingResult.iterationsUsed);
+		});
+
+		it('should respect max iterations limit', () => {
+			// Arrange
+			const graph = createComplexGraph();
+			const config: PageRankConfiguration = {
+				dampingFactor: 0.99, // High damping to slow convergence
+				maxIterations: 5,
+				convergenceThreshold: 1e-10 // Very strict threshold
+			};
+			
+			// Act
+			const result = pageRankAlgorithm.calculatePageRank(graph, config);
+			
+			// Assert
+			expect(result.iterationsUsed).toBeLessThanOrEqual(5);
+		});
+
+		it('should handle disconnected components', () => {
+			// Arrange
+			const graph = createDisconnectedGraph();
+			
+			// Act
+			const result = pageRankAlgorithm.calculatePageRank(graph, DEFAULT_PAGERANK_CONFIG);
+			
+			// Assert
+			expect(result.scores.size).toBe(4);
+			expect(result.convergenceAchieved).toBe(true);
+			
+			// All nodes should have positive scores
+			Array.from(result.scores.values()).forEach(score => {
+				expect(score).toBeGreaterThan(0);
+			});
+		});
+	});
+
+	describe('normalizeScores', () => {
+		it('should normalize scores to 0-100 range', () => {
+			// Arrange
+			const scores = new Map([
+				['node1', 0.5],
+				['node2', 0.3],
+				['node3', 0.2]
+			]);
+			
+			// Act
+			const normalized = pageRankAlgorithm.normalizeScores(scores);
+			
+			// Assert
+			expect(normalized.size).toBe(3);
+			expect(normalized.get('node1')).toBe(100); // Highest score -> 100
+			expect(normalized.get('node3')).toBe(0);   // Lowest score -> 0
+			expect(normalized.get('node2')).toBe(50);  // Middle score -> 50
+		});
+
+		it('should handle equal scores', () => {
+			// Arrange
+			const scores = new Map([
+				['node1', 0.33],
+				['node2', 0.33],
+				['node3', 0.33]
+			]);
+			
+			// Act
+			const normalized = pageRankAlgorithm.normalizeScores(scores);
+			
+			// Assert
+			expect(normalized.size).toBe(3);
+			// All should get middle value when range is 0
+			expect(normalized.get('node1')).toBe(50);
+			expect(normalized.get('node2')).toBe(50);
+			expect(normalized.get('node3')).toBe(50);
+		});
+
+		it('should handle empty scores map', () => {
+			// Arrange
+			const scores = new Map<string, number>();
+			
+			// Act
+			const normalized = pageRankAlgorithm.normalizeScores(scores);
+			
+			// Assert
+			expect(normalized.size).toBe(0);
+		});
+	});
+
+	describe('createRankings', () => {
+		it('should create correct rankings from scores', () => {
+			// Arrange
+			const scores = new Map([
+				['node1', 75],
+				['node2', 100],
+				['node3', 50]
+			]);
+			
+			// Act
+			const rankings = pageRankAlgorithm.createRankings(scores);
+			
+			// Assert
+			expect(rankings.size).toBe(3);
+			expect(rankings.get('node2')).toBe(1); // Highest score -> rank 1
+			expect(rankings.get('node1')).toBe(2); // Second highest -> rank 2
+			expect(rankings.get('node3')).toBe(3); // Lowest -> rank 3
+		});
+
+		it('should handle tied scores correctly', () => {
+			// Arrange
+			const scores = new Map([
+				['node1', 100],
+				['node2', 100], // Tied for first
+				['node3', 50],
+				['node4', 50]   // Tied for third
+			]);
+			
+			// Act
+			const rankings = pageRankAlgorithm.createRankings(scores);
+			
+			// Assert
+			expect(rankings.size).toBe(4);
+			expect(rankings.get('node1')).toBe(1);
+			expect(rankings.get('node2')).toBe(1); // Both tied at rank 1
+			expect(rankings.get('node3')).toBe(3); // Next rank is 3 (skipping 2)
+			expect(rankings.get('node4')).toBe(3); // Both tied at rank 3
+		});
+
+		it('should handle empty scores map', () => {
+			// Arrange
+			const scores = new Map<string, number>();
+			
+			// Act
+			const rankings = pageRankAlgorithm.createRankings(scores);
+			
+			// Assert
+			expect(rankings.size).toBe(0);
+		});
+	});
+
+	// Helper functions
+	function createSimpleGraph(): TrustGraph {
+		const graph = new TrustGraph();
+		const vertex1 = new Vertex('node1');
+		const vertex2 = new Vertex('node2');
+		const vertex3 = new Vertex('node3');
+		
+		graph.addVertex(vertex1);
+		graph.addVertex(vertex2);
+		graph.addVertex(vertex3);
+		
+		// Create a simple cycle: 1 -> 2 -> 3 -> 1
+		graph.addEdge(vertex1, vertex2);
+		graph.addEdge(vertex2, vertex3);
+		graph.addEdge(vertex3, vertex1);
+		
+		return graph;
+	}
+
+	function createComplexGraph(): TrustGraph {
+		const graph = new TrustGraph();
+		const vertices = [];
+		
+		// Create 5 vertices
+		for (let i = 1; i <= 5; i++) {
+			const vertex = new Vertex(`node${i}`);
+			vertices.push(vertex);
+			graph.addVertex(vertex);
+		}
+		
+		// Create a more complex trust structure
+		graph.addEdge(vertices[0], vertices[1]); // 1 -> 2
+		graph.addEdge(vertices[0], vertices[2]); // 1 -> 3
+		graph.addEdge(vertices[1], vertices[2]); // 2 -> 3
+		graph.addEdge(vertices[1], vertices[3]); // 2 -> 4
+		graph.addEdge(vertices[2], vertices[4]); // 3 -> 5
+		graph.addEdge(vertices[3], vertices[0]); // 4 -> 1 (creates cycle)
+		graph.addEdge(vertices[4], vertices[0]); // 5 -> 1
+		
+		return graph;
+	}
+
+	function createDisconnectedGraph(): TrustGraph {
+		const graph = new TrustGraph();
+		
+		// Component 1: two connected nodes
+		const vertex1 = new Vertex('node1');
+		const vertex2 = new Vertex('node2');
+		graph.addVertex(vertex1);
+		graph.addVertex(vertex2);
+		graph.addEdge(vertex1, vertex2);
+		
+		// Component 2: two isolated nodes
+		const vertex3 = new Vertex('node3');
+		const vertex4 = new Vertex('node4');
+		graph.addVertex(vertex3);
+		graph.addVertex(vertex4);
+		// No edges between components
+		
+		return graph;
+	}
+});

--- a/apps/backend/src/network-scan/domain/trust/__tests__/TrustRankCalculator.test.ts
+++ b/apps/backend/src/network-scan/domain/trust/__tests__/TrustRankCalculator.test.ts
@@ -1,0 +1,319 @@
+import { TrustRankCalculator } from '../TrustRankCalculator';
+import { PageRankAlgorithm } from '../PageRankAlgorithm';
+import { TrustGraph, Vertex } from 'shared';
+import { NodeTrustData, DEFAULT_PAGERANK_CONFIG } from '../TrustMetrics';
+
+describe('TrustRankCalculator', () => {
+	let trustRankCalculator: TrustRankCalculator;
+	let mockPageRankAlgorithm: jest.Mocked<PageRankAlgorithm>;
+
+	beforeEach(() => {
+		trustRankCalculator = new TrustRankCalculator();
+		// Replace the internal PageRank algorithm with a mock
+		mockPageRankAlgorithm = {
+			calculatePageRank: jest.fn(),
+			normalizeScores: jest.fn(),
+			createRankings: jest.fn()
+		} as jest.Mocked<PageRankAlgorithm>;
+		(trustRankCalculator as any).pageRankAlgorithm = mockPageRankAlgorithm;
+	});
+
+	describe('calculateTrustMetrics', () => {
+		it('should calculate trust metrics for a simple network', () => {
+			// Arrange
+			const trustGraph = createSimpleTrustGraph();
+			const nodeData = createSimpleNodeData();
+			
+			const mockPageRankScores = new Map([
+				['node1', 0.4],
+				['node2', 0.3],
+				['node3', 0.3]
+			]);
+			
+			const mockNormalizedScores = new Map([
+				['node1', 100],
+				['node2', 75],
+				['node3', 50]
+			]);
+			
+			const mockRankings = new Map([
+				['node1', 1],
+				['node2', 2],
+				['node3', 3]
+			]);
+
+			mockPageRankAlgorithm.calculatePageRank.mockReturnValue({
+				scores: mockPageRankScores,
+				convergenceAchieved: true,
+				iterationsUsed: 10
+			});
+			mockPageRankAlgorithm.normalizeScores
+				.mockReturnValueOnce(mockNormalizedScores) // First call for PageRank normalization
+				.mockReturnValueOnce(mockNormalizedScores); // Second call for trust centrality normalization
+			mockPageRankAlgorithm.createRankings.mockReturnValue(mockRankings);
+
+			// Act
+			const result = trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+			// Assert
+			expect(result.trustMetrics.size).toBe(3);
+			expect(result.convergenceAchieved).toBe(true);
+			expect(result.iterationsUsed).toBe(10);
+			expect(result.calculationTimestamp).toBeInstanceOf(Date);
+
+			const node1Metrics = result.trustMetrics.get('node1');
+			expect(node1Metrics).toBeDefined();
+			expect(node1Metrics!.pageRankScore).toBe(100);
+			expect(node1Metrics!.trustRank).toBe(1);
+			expect(node1Metrics!.lastTrustCalculation).toBeInstanceOf(Date);
+		});
+
+		it('should use default configuration when none provided', () => {
+			// Arrange
+			const trustGraph = createSimpleTrustGraph();
+			const nodeData = createSimpleNodeData();
+			
+			mockPageRankAlgorithm.calculatePageRank.mockReturnValue({
+				scores: new Map(),
+				convergenceAchieved: true,
+				iterationsUsed: 1
+			});
+			mockPageRankAlgorithm.normalizeScores.mockReturnValue(new Map());
+			mockPageRankAlgorithm.createRankings.mockReturnValue(new Map());
+
+			// Act
+			trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+			// Assert
+			expect(mockPageRankAlgorithm.calculatePageRank).toHaveBeenCalledWith(
+				trustGraph,
+				DEFAULT_PAGERANK_CONFIG
+			);
+		});
+
+		it('should apply organizational diversity bonuses', () => {
+			// Arrange
+			const trustGraph = createDiverseTrustGraph();
+			const nodeData = createDiverseNodeData();
+			
+			const mockPageRankScores = new Map([
+				['node1', 0.33],
+				['node2', 0.33],
+				['node3', 0.34]
+			]);
+			
+			const mockNormalizedScores = new Map([
+				['node1', 50],
+				['node2', 50],
+				['node3', 50]
+			]);
+
+			mockPageRankAlgorithm.calculatePageRank.mockReturnValue({
+				scores: mockPageRankScores,
+				convergenceAchieved: true,
+				iterationsUsed: 5
+			});
+			mockPageRankAlgorithm.normalizeScores
+				.mockReturnValueOnce(mockNormalizedScores)
+				.mockReturnValueOnce(new Map([
+					['node1', 100], // Should get highest score due to organizational diversity
+					['node2', 75],
+					['node3', 50]
+				]));
+			mockPageRankAlgorithm.createRankings.mockReturnValue(new Map([
+				['node1', 1],
+				['node2', 2],
+				['node3', 3]
+			]));
+
+			// Act
+			const result = trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+			// Assert
+			const node1Metrics = result.trustMetrics.get('node1');
+			expect(node1Metrics!.trustCentralityScore).toBe(100);
+			
+			// Verify that trust centrality normalization was called
+			expect(mockPageRankAlgorithm.normalizeScores).toHaveBeenCalledTimes(2);
+		});
+
+		it('should apply validator bonuses', () => {
+			// Arrange
+			const trustGraph = createSimpleTrustGraph();
+			const nodeData = new Map<string, NodeTrustData>([
+				['node1', { organizationId: 'org1', isValidator: true }],
+				['node2', { organizationId: 'org2', isValidator: false }],
+				['node3', { organizationId: 'org3', isValidator: false }]
+			]);
+			
+			const mockPageRankScores = new Map([
+				['node1', 0.33],
+				['node2', 0.33],
+				['node3', 0.34]
+			]);
+			
+			const mockNormalizedScores = new Map([
+				['node1', 50],
+				['node2', 50],
+				['node3', 50]
+			]);
+
+			mockPageRankAlgorithm.calculatePageRank.mockReturnValue({
+				scores: mockPageRankScores,
+				convergenceAchieved: true,
+				iterationsUsed: 5
+			});
+			mockPageRankAlgorithm.normalizeScores
+				.mockReturnValueOnce(mockNormalizedScores)
+				.mockReturnValueOnce(new Map([
+					['node1', 100], // Validator should get higher score
+					['node2', 75],
+					['node3', 50]
+				]));
+			mockPageRankAlgorithm.createRankings.mockReturnValue(new Map([
+				['node1', 1],
+				['node2', 2],
+				['node3', 3]
+			]));
+
+			// Act
+			const result = trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+			// Assert
+			const node1Metrics = result.trustMetrics.get('node1');
+			expect(node1Metrics!.trustCentralityScore).toBe(100);
+		});
+
+		it('should handle empty trust graph', () => {
+			// Arrange
+			const trustGraph = new TrustGraph();
+			const nodeData = new Map<string, NodeTrustData>();
+			
+			mockPageRankAlgorithm.calculatePageRank.mockReturnValue({
+				scores: new Map(),
+				convergenceAchieved: true,
+				iterationsUsed: 0
+			});
+			mockPageRankAlgorithm.normalizeScores.mockReturnValue(new Map());
+			mockPageRankAlgorithm.createRankings.mockReturnValue(new Map());
+
+			// Act
+			const result = trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+			// Assert
+			expect(result.trustMetrics.size).toBe(0);
+			expect(result.convergenceAchieved).toBe(true);
+			expect(result.iterationsUsed).toBe(0);
+		});
+
+		it('should handle nodes without organization data', () => {
+			// Arrange
+			const trustGraph = createSimpleTrustGraph();
+			const nodeData = new Map<string, NodeTrustData>([
+				['node1', { organizationId: null, isValidator: false }],
+				['node2', { organizationId: undefined, isValidator: true }]
+			]);
+			
+			const mockPageRankScores = new Map([
+				['node1', 0.5],
+				['node2', 0.5],
+				['node3', 0.0]
+			]);
+			
+			const mockNormalizedScores = new Map([
+				['node1', 75],
+				['node2', 75],
+				['node3', 0]
+			]);
+
+			mockPageRankAlgorithm.calculatePageRank.mockReturnValue({
+				scores: mockPageRankScores,
+				convergenceAchieved: true,
+				iterationsUsed: 3
+			});
+			mockPageRankAlgorithm.normalizeScores
+				.mockReturnValueOnce(mockNormalizedScores)
+				.mockReturnValueOnce(mockNormalizedScores);
+			mockPageRankAlgorithm.createRankings.mockReturnValue(new Map([
+				['node1', 2],
+				['node2', 1],
+				['node3', 3]
+			]));
+
+			// Act
+			const result = trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+			// Assert
+			expect(result.trustMetrics.size).toBe(3);
+			
+			const node1Metrics = result.trustMetrics.get('node1');
+			const node2Metrics = result.trustMetrics.get('node2');
+			
+			expect(node1Metrics).toBeDefined();
+			expect(node2Metrics).toBeDefined();
+			
+			// Node2 should have higher score due to validator bonus
+			expect(node2Metrics!.trustRank).toBe(1);
+		});
+	});
+
+	// Helper functions
+	function createSimpleTrustGraph(): TrustGraph {
+		const graph = new TrustGraph();
+		const vertex1 = new Vertex('node1');
+		const vertex2 = new Vertex('node2');
+		const vertex3 = new Vertex('node3');
+		
+		graph.addVertex(vertex1);
+		graph.addVertex(vertex2);
+		graph.addVertex(vertex3);
+		
+		// Create some trust relationships
+		graph.addEdge(vertex1, vertex2);
+		graph.addEdge(vertex1, vertex3);
+		graph.addEdge(vertex2, vertex3);
+		
+		return graph;
+	}
+
+	function createSimpleNodeData(): Map<string, NodeTrustData> {
+		return new Map([
+			['node1', { organizationId: 'org1', isValidator: true }],
+			['node2', { organizationId: 'org2', isValidator: true }],
+			['node3', { organizationId: 'org3', isValidator: false }]
+		]);
+	}
+
+	function createDiverseTrustGraph(): TrustGraph {
+		const graph = new TrustGraph();
+		const vertex1 = new Vertex('node1');
+		const vertex2 = new Vertex('node2');
+		const vertex3 = new Vertex('node3');
+		const vertex4 = new Vertex('node4');
+		
+		graph.addVertex(vertex1);
+		graph.addVertex(vertex2);
+		graph.addVertex(vertex3);
+		graph.addVertex(vertex4);
+		
+		// Node1 receives trust from multiple organizations
+		graph.addEdge(vertex2, vertex1); // org2 -> org1
+		graph.addEdge(vertex3, vertex1); // org3 -> org1
+		graph.addEdge(vertex4, vertex1); // org4 -> org1
+		
+		// Node2 receives trust from single organization
+		graph.addEdge(vertex3, vertex2); // org3 -> org2
+		graph.addEdge(vertex4, vertex2); // org4 -> org2 (same as node3's org)
+		
+		return graph;
+	}
+
+	function createDiverseNodeData(): Map<string, NodeTrustData> {
+		return new Map([
+			['node1', { organizationId: 'org1', isValidator: true }],
+			['node2', { organizationId: 'org2', isValidator: true }],
+			['node3', { organizationId: 'org3', isValidator: true }],
+			['node4', { organizationId: 'org3', isValidator: true }] // Same org as node3
+		]);
+	}
+});

--- a/apps/backend/src/network-scan/infrastructure/di/container.ts
+++ b/apps/backend/src/network-scan/infrastructure/di/container.ts
@@ -105,6 +105,7 @@ import OrganizationMeasurementDay from '../../domain/organization/OrganizationMe
 import NodeMeasurementDay from '../../domain/node/NodeMeasurementDay';
 import NetworkMeasurementDay from '../../domain/network/NetworkMeasurementDay';
 import { CachedNetworkDTOService } from '../../services/CachedNetworkDTOService';
+import { TrustRankCalculator } from '../../domain/trust/TrustRankCalculator';
 
 export function load(container: Container, config: Config) {
 	container
@@ -329,6 +330,7 @@ function loadDomain(container: Container, config: Config) {
 	container.bind(NetworkScanner).toSelf();
 	container.bind(NodeScanner).toSelf();
 	container.bind(OrganizationScanner).toSelf();
+	container.bind(TrustRankCalculator).toSelf();
 }
 
 function loadUseCases(container: Container) {

--- a/apps/backend/src/network-scan/mappers/NodeV1DTOMapper.ts
+++ b/apps/backend/src/network-scan/mappers/NodeV1DTOMapper.ts
@@ -64,7 +64,11 @@ export class NodeV1DTOMapper {
 			organizationId: organizationId ?? null,
 			connectivityError: measurement?.connectivityError ?? false,
 			stellarCoreVersionBehind: measurement?.stellarCoreVersionBehind ?? false,
-			lag: measurement?.lag ?? null
+			lag: measurement?.lag ?? null,
+			trustCentralityScore: measurement?.trustCentralityScore ?? 0,
+			pageRankScore: measurement?.pageRankScore ?? 0,
+			trustRank: measurement?.trustRank ?? 0,
+			lastTrustCalculation: measurement?.lastTrustCalculation?.toISOString() ?? null
 		};
 	}
 

--- a/docs/phase-1-remaining-tasks.md
+++ b/docs/phase-1-remaining-tasks.md
@@ -1,0 +1,277 @@
+# Phase 1 Remaining Tasks: Trust Centrality Integration
+
+## Overview
+
+This document outlines the remaining tasks to complete Phase 1 of the Trust Visualization Enhancement Plan. Phase 1 focuses on implementing the backend foundation for trust-based node ranking using PageRank algorithm integrated into the existing network scanner workflow.
+
+## Current Status
+
+### ✅ Completed Tasks
+
+1. **Database Migration** - `1751570404901-trust-centrality-metrics.ts`
+   - Added `trustCentralityScore`, `pageRankScore`, `trustRank`, `lastTrustCalculation` columns
+   - Created performance indexes for efficient querying
+
+2. **Trust Calculation Services**
+   - `TrustMetrics.ts` - Core interfaces and configuration
+   - `PageRankAlgorithm.ts` - PageRank implementation with convergence detection
+   - `TrustRankCalculator.ts` - Main service with organizational diversity bonuses
+
+3. **Database Entity Updates**
+   - Updated `NodeSnapShot.ts` entity with trust properties
+   - Enhanced copy method for proper versioning
+
+4. **Shared Interface Updates**
+   - Updated `Node.ts` class with trust properties
+   - Enhanced serialization/deserialization methods
+
+5. **API Compatibility**
+   - Updated `NodeV1` DTO interface and JSON schema
+   - Maintained backward compatibility
+
+## 🔄 Remaining Tasks
+
+### High Priority - Core Integration
+
+#### Task 1: Complete Node DTOs for API Compatibility
+**Status**: In Progress (95% complete)
+**Files**: `/packages/shared/src/dto/node-v1.ts`
+**Remaining Work**: Final verification that all DTO updates are correct
+
+**Verification Checklist**:
+- [ ] Confirm all trust fields are properly typed in NodeV1 interface
+- [ ] Verify JSON schema includes all trust properties with correct validation
+- [ ] Test API serialization/deserialization with trust fields
+- [ ] Run any existing DTO validation tests
+
+---
+
+#### Task 2: Modify NodeScannerIndexerStep to Include Trust Calculation
+**Status**: Pending
+**Files**: `/apps/backend/src/network-scan/domain/node/scan/NodeScannerIndexerStep.ts`
+**Priority**: High
+
+**Implementation Details**:
+```typescript
+// Current flow: NodeScannerIndexerStep -> NodeIndexer.calculateIndexes()
+// New flow: NodeScannerIndexerStep -> TrustRankCalculator -> NodeIndexer.calculateIndexes()
+
+// Steps to implement:
+1. Inject TrustRankCalculator into NodeScannerIndexerStep
+2. Add trust calculation before index calculation
+3. Pass trust results to NodeIndexer
+4. Ensure proper error handling for trust calculation failures
+```
+
+**Key Requirements**:
+- Must execute after trust graph creation but before final indexing
+- Should handle cases where trust calculation fails gracefully
+- Need to collect node data (organization, validator status) for trust calculation
+- Must update NodeSnapshot entities with calculated trust metrics
+
+**Files to Modify**:
+- `/apps/backend/src/network-scan/domain/node/scan/NodeScannerIndexerStep.ts`
+- May need to update constructor and execute method
+
+---
+
+#### Task 3: Update NodeIndexer to Use PageRank Scores
+**Status**: Pending
+**Files**: `/apps/backend/src/network-scan/domain/node/scan/NodeIndexer.ts`
+**Priority**: High
+
+**Current Implementation Analysis**:
+- Existing: Uses `TrustIndex.get()` for simple in-degree calculation
+- New: Should incorporate or replace with PageRank-based trust scores
+
+**Implementation Options**:
+1. **Replace TrustIndex**: Use `trustCentralityScore` instead of current trust index
+2. **Enhance TrustIndex**: Modify `TrustIndex.get()` to use PageRank when available
+3. **Hybrid Approach**: Combine PageRank with existing metrics
+
+**Recommended Approach**: Enhance TrustIndex to use PageRank scores when available, fallback to current method
+
+**Files to Modify**:
+- `/apps/backend/src/network-scan/domain/node/scan/NodeIndexer.ts`
+- `/apps/backend/src/network-scan/domain/node/scan/node-index/index/trust-index.ts`
+
+---
+
+#### Task 4: Register TrustRankCalculator in DI Container
+**Status**: Pending
+**Files**: 
+- `/apps/backend/src/network-scan/infrastructure/di/container.ts`
+- `/apps/backend/src/network-scan/infrastructure/di/di-types.ts`
+**Priority**: High
+
+**Implementation Steps**:
+
+1. **Add DI Type**:
+```typescript
+// In di-types.ts
+export const TYPES = {
+    // ... existing types
+    TrustRankCalculator: Symbol.for('TrustRankCalculator'),
+};
+```
+
+2. **Register Service**:
+```typescript
+// In container.ts
+import { TrustRankCalculator } from '../domain/trust/TrustRankCalculator';
+
+container.bind<ITrustRankCalculator>(TYPES.TrustRankCalculator)
+    .to(TrustRankCalculator)
+    .inSingletonScope();
+```
+
+3. **Update Injection Points**:
+- Add TrustRankCalculator injection to NodeScannerIndexerStep constructor
+
+---
+
+### Medium Priority - Quality Assurance
+
+#### Task 5: Create Unit Tests for TrustRankCalculator
+**Status**: Pending
+**Files**: `/apps/backend/src/network-scan/domain/trust/__tests__/`
+**Priority**: Medium
+
+**Test Coverage Requirements**:
+
+1. **PageRankAlgorithm Tests**:
+   - Test convergence with simple graphs
+   - Test handling of disconnected components
+   - Test normalization accuracy
+   - Test ranking creation with ties
+   - Performance tests with large graphs
+
+2. **TrustRankCalculator Tests**:
+   - Test organizational diversity bonus calculation
+   - Test validator bonus application
+   - Test integration with TrustGraph
+   - Test error handling for invalid inputs
+
+3. **TrustMetrics Tests**:
+   - Test configuration validation
+   - Test result data structures
+
+**Test Files to Create**:
+```
+/apps/backend/src/network-scan/domain/trust/__tests__/
+├── PageRankAlgorithm.test.ts
+├── TrustRankCalculator.test.ts
+├── TrustMetrics.test.ts
+└── fixtures/
+    ├── test-trust-graphs.ts
+    └── test-node-data.ts
+```
+
+---
+
+#### Task 6: Verify Integration with Existing Scanner Workflow
+**Status**: Pending
+**Priority**: Medium
+
+**Integration Testing Requirements**:
+
+1. **End-to-End Scanner Test**:
+   - Run complete network scan with trust calculation enabled
+   - Verify trust metrics are calculated and stored
+   - Confirm no performance degradation
+   - Test with various network topologies
+
+2. **Database Integration Test**:
+   - Verify migration runs successfully
+   - Test trust metric persistence
+   - Confirm index performance improvements
+
+3. **Error Handling Test**:
+   - Test behavior when trust calculation fails
+   - Verify graceful degradation
+   - Test with malformed trust graphs
+
+**Test Scenarios**:
+- Small network (< 10 nodes)
+- Medium network (10-100 nodes)  
+- Large network (> 100 nodes)
+- Network with no trust relationships
+- Network with complex organizational structures
+
+---
+
+## Implementation Order
+
+**Recommended Sequence**:
+
+1. **Complete DTO verification** (30 minutes)
+2. **Register TrustRankCalculator in DI** (30 minutes)
+3. **Modify NodeScannerIndexerStep** (2-3 hours)
+4. **Update NodeIndexer** (1-2 hours)
+5. **Create unit tests** (4-6 hours)
+6. **Integration testing** (2-3 hours)
+
+**Total Estimated Time**: 10-15 hours
+
+## Risk Mitigation
+
+### Performance Risks
+- **Risk**: Trust calculation slows down network scanning
+- **Mitigation**: 
+  - Implement async trust calculation
+  - Add performance monitoring
+  - Consider caching trust results
+
+### Data Integrity Risks
+- **Risk**: Trust calculation errors corrupt node data
+- **Mitigation**:
+  - Comprehensive error handling
+  - Transaction rollback on calculation failure
+  - Extensive testing with edge cases
+
+### Backwards Compatibility Risks
+- **Risk**: Changes break existing functionality
+- **Mitigation**:
+  - Maintain all existing interfaces
+  - Default trust scores to safe values (0)
+  - Progressive enhancement approach
+
+## Success Criteria
+
+### Functional Requirements
+- [ ] Trust metrics are calculated for all nodes during network scan
+- [ ] Trust scores are properly stored in database
+- [ ] Scanner performance remains acceptable (< 20% slowdown)
+- [ ] All existing functionality continues to work
+
+### Quality Requirements
+- [ ] > 90% test coverage for new trust calculation code
+- [ ] No memory leaks in trust calculation
+- [ ] Proper error logging and monitoring
+- [ ] Documentation for trust calculation parameters
+
+## Rollback Plan
+
+If integration issues arise:
+
+1. **Database**: Migration can be rolled back safely
+2. **Code**: Feature flag to disable trust calculation
+3. **Fallback**: Use existing trust index until issues resolved
+
+## Documentation Updates Needed
+
+After completion:
+- Update API documentation with new trust fields
+- Add trust calculation configuration guide
+- Document performance tuning parameters
+- Create troubleshooting guide for trust calculation issues
+
+## Monitoring and Observability
+
+Add monitoring for:
+- Trust calculation execution time
+- Trust calculation success/failure rates
+- Trust score distribution across network
+- Memory usage during trust calculation
+
+This completes the documentation for Phase 1 remaining tasks. The foundation is solid, and these integration tasks will make the trust calculation system fully operational.

--- a/docs/trust-visualization-enhancement-plan.md
+++ b/docs/trust-visualization-enhancement-plan.md
@@ -1,0 +1,249 @@
+# Trust Visualization Enhancement Plan for OBSRVR Radar
+
+## Executive Summary
+
+This document outlines a comprehensive plan to enhance the OBSRVR Radar interface to better communicate node trust relationships and importance within the Stellar network. The goal is to help users easily distinguish between nodes that are genuinely important to network consensus versus those that may appear prominent but lack broad organizational support.
+
+## Problem Statement
+
+### Current Issue
+The current OBSRVR Radar interface can be confusing because:
+- Nodes without incoming trust lines (like sl8 validators) may appear to dominate the network
+- Untrained users cannot easily identify which nodes have high levels of trust from other organizations
+- This confusion may lead new validator operators to make poor quorum configuration decisions
+- The interface doesn't clearly communicate node importance based on trust relationships
+
+### Impact
+- **User Experience**: Confusing interface for new users
+- **Network Health**: Potential for poor quorum configuration decisions
+- **Trust Understanding**: Difficulty assessing actual network influence vs. apparent prominence
+
+## Current System Analysis
+
+### 1. Node Display Mechanisms
+**Tables & Lists:**
+- `/components/node/nodes-table.vue`: Main node listing with basic info (name, organization, validator status)
+- `/components/network/cards/network-nodes.vue`: Dashboard widget showing active validators with simple filtering
+- Current sorting: by `index` property (descending) - appears to be a basic ranking metric
+
+**Visual Graph:**
+- `/components/visual-navigator/graph/graph.vue`: Network trust graph with D3.js visualization
+- Shows nodes as circles with color coding for active/failing/selected states
+- Highlights trusted/trusting relationships when nodes are selected
+
+### 2. Trust Relationship Display
+**Current Approach:**
+- Trust relationships shown as edges in graph visualization
+- `NodeTrustGraphBuilder.ts`: Creates directional trust graph from quorum sets
+- Trust is one-way: A trusts B if B is in A's quorum set
+- Colors: incoming trust (teal #73bfb8), outgoing trust (yellow #fec601)
+
+**Trust Information Cards:**
+- `node-trusted-by.vue`: Shows nodes that trust the selected node
+- Simple count display with no ranking or importance weighting
+
+### 3. Current Ranking/Scoring
+**Limited Ranking Systems:**
+- Node `index` property: Basic ranking metric (higher = more important)
+- Network analysis focuses on blocking sets, quorum intersection, but no trust-based importance
+- No existing TrustRank or PageRank-style algorithm
+- No visual distinction between highly-trusted vs poorly-trusted nodes
+
+### 4. Color Coding System
+**Current Colors:**
+- Blue (#1997c6): Active/validating nodes
+- Red: Failing nodes  
+- Yellow: Selected nodes
+- Gray: Inactive nodes
+- Teal (#73bfb8): Incoming trust connections
+- Yellow (#fec601): Outgoing trust connections
+
+**Missing:**
+- No color coding for trust importance/centrality
+- No visual indicators for "trust authority" vs "trust dependent" nodes
+- No mechanism to highlight organizationally-diverse trust
+
+## Proposed Enhancement Plan
+
+### Phase 1: Trust Centrality Calculation Service
+
+#### 1.1 TrustRankCalculator Service
+**Implementation:**
+- Create new service: `apps/backend/src/network/services/TrustRankCalculator.ts`
+- Implement PageRank-style algorithm adapted for trust networks
+- Calculate trust scores weighted by organizational diversity
+- Account for cross-organizational trust (higher weight for diverse trust sources)
+
+**Algorithm Components:**
+- **Base Trust Score**: PageRank calculation on trust graph
+- **Organizational Diversity Bonus**: Higher scores for nodes trusted by multiple organizations
+- **Decay Factor**: Reduce influence of nodes with low incoming trust
+- **Normalization**: Scale scores to 0-100 range for UI display
+
+#### 1.2 Database Schema Updates
+**Node Table Extensions:**
+```sql
+ALTER TABLE node ADD COLUMN trust_score DECIMAL(5,2) DEFAULT 0;
+ALTER TABLE node ADD COLUMN organizational_trust_diversity DECIMAL(5,2) DEFAULT 0;
+ALTER TABLE node ADD COLUMN incoming_trust_count INTEGER DEFAULT 0;
+ALTER TABLE node ADD COLUMN outgoing_trust_count INTEGER DEFAULT 0;
+```
+
+#### 1.3 Interface Updates
+**Node Interface Extensions:**
+```typescript
+interface Node {
+  // ... existing properties
+  trustScore: number;
+  organizationalTrustDiversity: number;
+  incomingTrustCount: number;
+  outgoingTrustCount: number;
+}
+```
+
+### Phase 2: Enhanced Visual Indicators
+
+#### 2.1 Trust-Based Color Gradient System
+**Implementation:**
+- Create color gradient based on trust score
+- High trust authority: Deep blue/green (#004d4d to #1997c6)
+- Medium trust: Standard blue (#1997c6)
+- Low/no incoming trust: Light blue/gray (#cce7f0 to #e6f3f7)
+- Warning state: Orange/yellow border for nodes with concerning trust patterns
+
+#### 2.2 Node Size Scaling
+**Visual Hierarchy:**
+- Scale node circle radius based on trust importance
+- Base size: 8px radius
+- High trust nodes: Up to 16px radius
+- Low trust nodes: Down to 4px radius
+- Maintain readability with minimum size constraints
+
+#### 2.3 Trust Quality Badges
+**Badge System:**
+- **Gold Star**: High organizational diversity (5+ different orgs)
+- **Silver Star**: Medium diversity (3-4 orgs)
+- **Warning Triangle**: Low/no incoming trust
+- **Diversity Ring**: Visual indicator of cross-organizational trust
+
+### Phase 3: Improved Table Displays
+
+#### 3.1 Enhanced Node Tables
+**New Columns:**
+- **Trust Score**: Numerical score (0-100) with sorting
+- **Trusted By**: Count with organizational breakdown tooltip
+- **Trust Quality**: Badge/icon indicating trust diversity
+- **Organizational Reach**: Number of different organizations that trust this node
+
+#### 3.2 Default Sorting and Filtering
+**Improved Defaults:**
+- Default sort by trust importance instead of index
+- Secondary sort by organizational diversity
+- Tertiary sort by uptime/reliability
+
+#### 3.3 Trust Warnings and Indicators
+**Visual Indicators:**
+- **Red Warning**: Nodes with zero incoming trust
+- **Yellow Caution**: Nodes with low organizational diversity
+- **Green Check**: Well-trusted nodes with good diversity
+- **Info Icon**: Hover tooltips explaining trust metrics
+
+### Phase 4: Advanced Filtering & Analysis
+
+#### 4.1 Trust-Based Filters
+**Filter Options:**
+- "Show only well-trusted nodes" toggle
+- Minimum trust score slider
+- Organizational diversity filter
+- Trust relationship type filters
+
+#### 4.2 Trust Analysis Dashboard
+**New Dashboard Components:**
+- **Trust Centralization Metrics**: Gini coefficient for trust distribution
+- **Organization-Level Trust Analysis**: Inter-organizational trust matrix
+- **Trust Concentration Warnings**: Alerts for concerning trust patterns
+- **Historical Trust Trends**: Trust score changes over time
+
+#### 4.3 Advanced Visualizations
+**New Visualization Features:**
+- **Trust Heatmap**: Grid showing trust relationships between organizations
+- **Trust Flow Diagram**: Sankey-style diagram showing trust flow
+- **Trust Clustering**: Group nodes by trust communities
+- **Trust Path Analysis**: Show trust paths between nodes
+
+## Implementation Strategy
+
+### Phase 1: Backend Foundation (Weeks 1-2)
+1. Implement TrustRankCalculator service
+2. Create database migrations for trust metrics
+3. Update Node model and interfaces
+4. Add trust calculation to network scan process
+
+### Phase 2: Frontend Enhancements (Weeks 3-4)
+1. Implement trust-based color gradients
+2. Add node size scaling based on trust
+3. Create trust quality badge system
+4. Update graph visualization components
+
+### Phase 3: UI/UX Improvements (Weeks 5-6)
+1. Enhance node tables with trust columns
+2. Implement trust-based sorting and filtering
+3. Add trust warning indicators
+4. Create trust tooltips and help text
+
+### Phase 4: Advanced Features (Weeks 7-8)
+1. Build trust analysis dashboard
+2. Implement advanced filtering options
+3. Add trust-based visualizations
+4. Create trust metrics documentation
+
+## Success Metrics
+
+### User Experience Metrics
+- **Reduced Confusion**: Survey new users about network understanding
+- **Improved Decision Making**: Track quorum configuration quality
+- **Engagement**: Monitor time spent on trust-related features
+
+### Technical Metrics
+- **Trust Score Accuracy**: Validate against known network relationships
+- **Performance**: Ensure trust calculations don't slow down network scans
+- **Adoption**: Track usage of new trust-based features
+
+## Risk Mitigation
+
+### Algorithm Accuracy
+- **Risk**: Trust algorithm may not accurately reflect network reality
+- **Mitigation**: Validate against known network relationships, iterate based on feedback
+
+### Performance Impact
+- **Risk**: Trust calculations may slow down network processing
+- **Mitigation**: Optimize algorithms, consider caching, run calculations async
+
+### User Adoption
+- **Risk**: Users may not understand or use new trust features
+- **Mitigation**: Provide clear documentation, tutorials, and gradual rollout
+
+## Future Enhancements
+
+### Machine Learning Integration
+- Use ML to predict trust relationship changes
+- Anomaly detection for unusual trust patterns
+- Automated trust quality assessment
+
+### Cross-Network Analysis
+- Compare trust patterns across different Stellar networks
+- Identify best practices from well-decentralized networks
+- Benchmark trust metrics against other networks
+
+### Community Features
+- Allow community feedback on trust assessments
+- Crowdsourced trust quality ratings
+- Trust-based reputation systems
+
+## Conclusion
+
+This comprehensive plan addresses the core issue of trust visualization in the OBSRVR Radar interface. By implementing trust-based scoring, enhanced visual indicators, and improved filtering options, we can help users make better-informed decisions about network participation and quorum configuration.
+
+The phased approach allows for iterative development and testing, ensuring that each enhancement builds upon previous work while maintaining system stability and performance.
+
+The ultimate goal is to create an interface that clearly communicates which nodes are genuinely important to network consensus, helping users avoid the confusion that can lead to poor quorum configuration decisions.

--- a/docs/trust-visualization-phase1.md
+++ b/docs/trust-visualization-phase1.md
@@ -1,0 +1,266 @@
+# Trust Visualization Phase 1: Core Implementation
+
+## Overview
+
+Phase 1 implements the backend foundation for trust visualization in Stellarbeat, addressing SDF feedback about sl8 validators appearing to dominate the network when they lack incoming trust from other organizations. The solution distinguishes nodes with genuine cross-organizational trust from those that appear prominent but lack broad network support.
+
+## Problem Statement
+
+**Original Issue**: SDF reported that sl8 validators appear to dominate the network visualization despite having minimal incoming trust from other organizations. The existing trust calculation was too simplistic, using only direct trust counts without considering:
+
+- **Organizational diversity** of trust relationships
+- **Quality vs quantity** of trust connections
+- **Network-wide importance** vs local prominence
+
+## Solution: PageRank with Organizational Diversity
+
+Phase 1 implements a sophisticated trust scoring system based on:
+
+1. **PageRank Algorithm**: Measures network-wide importance of nodes
+2. **Organizational Diversity Bonuses**: Rewards nodes trusted by multiple different organizations
+3. **Validator Bonuses**: Gives additional weight to consensus participants
+4. **Normalized Scoring**: 0-100 scale for consistent comparison
+
+## Technical Implementation
+
+### 1. Database Schema (`1751570404901-trust-centrality-metrics.ts`)
+
+Added trust metrics columns to store calculated scores:
+
+```sql
+-- Node snapshots (historical data)
+ALTER TABLE "node_snap_shot" ADD "trustCentralityScore" decimal(12,8) DEFAULT 0;
+ALTER TABLE "node_snap_shot" ADD "pageRankScore" decimal(12,8) DEFAULT 0;
+ALTER TABLE "node_snap_shot" ADD "trustRank" integer DEFAULT 0;
+ALTER TABLE "node_snap_shot" ADD "lastTrustCalculation" timestamptz;
+
+-- Node measurements (real-time data)
+ALTER TABLE "node_measurement_v2" ADD "trustCentralityScore" decimal(12,8) DEFAULT 0;
+ALTER TABLE "node_measurement_v2" ADD "pageRankScore" decimal(12,8) DEFAULT 0;
+ALTER TABLE "node_measurement_v2" ADD "trustRank" integer DEFAULT 0;
+ALTER TABLE "node_measurement_v2" ADD "lastTrustCalculation" timestamptz;
+```
+
+**Note**: Updated from `decimal(10,8)` to `decimal(12,8)` to support values up to 9999.99999999.
+
+### 2. Trust Calculation Engine
+
+#### PageRankAlgorithm (`PageRankAlgorithm.ts`)
+- **Core Algorithm**: Implements standard PageRank with configurable damping factor (0.85)
+- **Convergence Detection**: Stops when score changes fall below threshold (1e-6)
+- **Normalization**: Converts raw scores to 0-100 scale
+- **Ranking**: Creates ordinal rankings handling ties properly
+
+#### TrustRankCalculator (`TrustRankCalculator.ts`)
+- **Trust Centrality**: Enhances PageRank with organizational diversity
+- **Organizational Diversity Bonus**: 
+  - Analyzes incoming trust sources by organization
+  - Multiplier: 1.0 + (unique_orgs/5 * 0.5) + (diversity_ratio * 0.5)
+  - Capped at 2.0x maximum bonus
+- **Validator Bonus**: 1.1x multiplier for consensus participants
+- **Score Bounds**: Ensures final scores stay within 0-100 range
+
+### 3. Scanner Integration
+
+#### NodeScannerIndexerStep (`NodeScannerIndexerStep.ts`)
+**Enhanced to include trust calculation**:
+
+```typescript
+public execute(nodeScan: NodeScan, measurement30DayAverages: NodeMeasurementAverage[], stellarCoreVersion: StellarCoreVersion): void {
+    // 1. Calculate trust metrics for all nodes
+    const trustGraph = TrustGraphFactory.create(nodeScan.nodes);
+    const nodeData = this.buildNodeTrustData(nodeScan.nodes);
+    const trustResult = this.trustRankCalculator.calculateTrustMetrics(trustGraph, nodeData);
+
+    // 2. Update nodes with trust metrics
+    nodeScan.nodes.forEach(node => {
+        const trustMetrics = trustResult.trustMetrics.get(node.publicKey.value);
+        if (trustMetrics) {
+            const latestMeasurement = node.latestMeasurement();
+            if (latestMeasurement) {
+                latestMeasurement.trustCentralityScore = trustMetrics.trustCentralityScore;
+                latestMeasurement.pageRankScore = trustMetrics.pageRankScore;
+                latestMeasurement.trustRank = trustMetrics.trustRank;
+                latestMeasurement.lastTrustCalculation = trustMetrics.lastTrustCalculation;
+            }
+        }
+    });
+
+    // 3. Calculate node indexes using enhanced trust scores
+    nodeScan.updateIndexes(NodeIndexer.calculateIndexes(nodeScan.nodes, measurement30DayAverages, stellarCoreVersion));
+}
+```
+
+#### NodeIndexer (`NodeIndexer.ts`)
+**Enhanced to use PageRank scores in index calculation**:
+
+```typescript
+// Use pre-calculated trust score if available, otherwise fall back to old calculation
+const trustScore = node.trustCentralityScore !== undefined 
+    ? node.trustCentralityScore / 100  // Convert 0-100 scale to 0-1 scale
+    : TrustIndex.get(node.publicKey, trustGraph);
+
+const indexRaw = (TypeIndex.get(...) + ActiveIndex.get(...) + ValidatingIndex.get(...) + 
+                  VersionIndex.get(...) + trustScore + AgeIndex.get(...)) / 6;
+```
+
+### 4. API Integration
+
+#### Shared Node Interface (`packages/shared/src/node.ts`)
+Added trust properties to Node class:
+
+```typescript
+public trustCentralityScore: number = 0;
+public pageRankScore: number = 0;
+public trustRank: number = 0;
+public lastTrustCalculation: Date | null = null;
+```
+
+#### NodeV1DTOMapper (`NodeV1DTOMapper.ts`)
+Enhanced API responses to include trust data:
+
+```typescript
+trustCentralityScore: node.trustCentralityScore || 0,
+pageRankScore: node.pageRankScore || 0,
+trustRank: node.trustRank || 0,
+lastTrustCalculation: node.lastTrustCalculation?.toISOString() || null
+```
+
+### 5. Dependency Injection
+
+Registered `TrustRankCalculator` in DI container (`container.ts`):
+
+```typescript
+container.bind(TrustRankCalculator).toSelf();
+```
+
+## Data Flow
+
+1. **Network Scan Triggers**: Every network scan now includes trust calculation
+2. **Trust Graph Creation**: `TrustGraphFactory.create()` builds graph from node relationships
+3. **PageRank Calculation**: Base algorithm computes network-wide importance scores
+4. **Trust Enhancement**: Organizational diversity and validator bonuses applied
+5. **Score Storage**: Results stored in database via NodeMeasurement entities
+6. **API Exposure**: Trust scores included in all node API responses
+7. **Index Integration**: Node ranking uses enhanced trust scores
+
+## Configuration
+
+### PageRank Parameters
+```typescript
+export const DEFAULT_PAGERANK_CONFIG: PageRankConfiguration = {
+    dampingFactor: 0.85,        // Standard PageRank damping factor
+    maxIterations: 100,         // Maximum iterations before timeout
+    convergenceThreshold: 1e-6  // Convergence detection threshold
+};
+```
+
+### Trust Centrality Bonuses
+- **Organizational Diversity**: Up to 1.5x bonus for trust from multiple organizations
+- **Validator Status**: 1.1x bonus for consensus participants
+- **Maximum Multiplier**: 2.0x total (prevents extreme scores)
+
+## Testing
+
+### Unit Tests Created
+1. **TrustRankCalculator.test.ts**: Comprehensive tests for trust calculation logic
+   - Simple network calculations
+   - Organizational diversity bonuses
+   - Validator bonuses
+   - Edge cases (empty graphs, missing data)
+
+2. **PageRankAlgorithm.test.ts**: Tests for core PageRank implementation
+   - Basic algorithm correctness
+   - Convergence behavior
+   - Score normalization
+   - Ranking generation
+
+### Test Coverage
+- **Trust calculation accuracy**: Verifies correct PageRank computation
+- **Bonus application**: Tests organizational diversity and validator bonuses
+- **Edge cases**: Empty graphs, single nodes, disconnected components
+- **Configuration handling**: Different damping factors and thresholds
+
+## Performance Considerations
+
+### Algorithm Complexity
+- **PageRank**: O(k * E) where k = iterations, E = edges
+- **Trust Enhancement**: O(V * D) where V = vertices, D = average node degree
+- **Overall**: Linear with network size for typical Stellar network topology
+
+### Optimization Strategies
+- **Convergence Detection**: Stops early when scores stabilize
+- **Efficient Storage**: Uses Maps for O(1) score lookups
+- **Database Indexing**: Trust score columns indexed for query performance
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Database Precision Overflow**
+   - **Symptom**: "numeric field overflow" error
+   - **Cause**: Trust scores exceeded decimal(10,8) range
+   - **Solution**: Updated to decimal(12,8) to support higher values
+
+2. **Missing @injectable Decorator**
+   - **Symptom**: DI container errors about missing annotation
+   - **Cause**: TrustRankCalculator missing proper decoration
+   - **Solution**: Added `@injectable()` and `reflect-metadata` import
+
+3. **TypeScript Compilation Errors**
+   - **Symptom**: Build failures on import paths
+   - **Cause**: Using `@stellarbeat/shared` instead of `shared`
+   - **Solution**: Corrected import paths to use local package name
+
+## Verification
+
+### Database Verification
+```sql
+-- Check trust scores are being calculated
+SELECT public_key, trust_centrality_score, page_rank_score, trust_rank, last_trust_calculation 
+FROM node_measurement_v2 
+WHERE last_trust_calculation IS NOT NULL 
+ORDER BY trust_centrality_score DESC 
+LIMIT 10;
+```
+
+### API Verification
+Trust scores now appear in node API responses:
+```json
+{
+  "publicKey": "GABCD...",
+  "trustCentralityScore": 85.32,
+  "pageRankScore": 78.45,
+  "trustRank": 5,
+  "lastTrustCalculation": "2025-07-03T21:16:38.237Z"
+}
+```
+
+## What's Next: Phase 2 Preview
+
+Phase 1 provides the foundation for Phase 2 frontend visualization:
+
+### Planned Features
+1. **Trust Score Display**: Show trust metrics in node details
+2. **Visual Indicators**: Color-code nodes by trust centrality
+3. **Trust-based Filtering**: Filter nodes by trust thresholds
+4. **Organizational Analysis**: Highlight cross-organizational trust patterns
+5. **Historical Trends**: Track trust score changes over time
+
+### Technical Foundation Ready
+- ✅ **Database schema** supports historical trust data
+- ✅ **API endpoints** expose trust metrics
+- ✅ **Real-time calculation** during network scans
+- ✅ **Enhanced indexing** reflects trust in node rankings
+- ✅ **Comprehensive testing** ensures reliability
+
+## Impact
+
+**Addresses SDF Feedback**: The system now distinguishes nodes with genuine cross-organizational support from those that appear prominent due to simple metrics.
+
+**Example Scenarios**:
+- **sl8 validators**: May have high traditional metrics but lower trust centrality due to limited organizational diversity
+- **SDF nodes**: Likely to score high due to broad cross-organizational trust
+- **Well-connected independents**: Could score higher than expected due to diverse trust sources
+
+The trust calculation provides a more nuanced view of network importance that better reflects the decentralized nature and organizational structure of the Stellar network.

--- a/packages/shared/src/dto/node-v1.ts
+++ b/packages/shared/src/dto/node-v1.ts
@@ -52,6 +52,10 @@ export interface NodeV1 {
 	connectivityError: boolean;
 	stellarCoreVersionBehind: boolean;
 	lag: number | null;
+	trustCentralityScore: number;
+	pageRankScore: number;
+	trustRank: number;
+	lastTrustCalculation: string | null;
 }
 
 export const NodeV1Schema: JSONSchemaType<NodeV1> = {
@@ -156,7 +160,27 @@ export const NodeV1Schema: JSONSchemaType<NodeV1> = {
 		},
 		stellarCoreVersionBehind: {
 			type: 'boolean'
-		}
+		},
+		trustCentralityScore: {
+			type: 'number',
+			default: 0,
+			description: 'Trust centrality score (0-100) based on PageRank with organizational diversity'
+		},
+		pageRankScore: {
+			type: 'number',
+			default: 0,
+			description: 'Base PageRank score (0-100) in the trust graph'
+		},
+		trustRank: {
+			type: 'number',
+			default: 0,
+			description: 'Ranking position based on trust centrality score (1 = highest)'
+		},
+		lastTrustCalculation: nullable({
+			type: 'string',
+			format: 'date-time',
+			description: 'Timestamp of the last trust calculation'
+		})
 	},
 	type: 'object',
 	required: [
@@ -187,7 +211,14 @@ export const NodeV1Schema: JSONSchemaType<NodeV1> = {
 		'quorumSet',
 		'statistics',
 		'geoData',
-		'homeDomain'
+		'homeDomain',
+		'connectivityError',
+		'stellarCoreVersionBehind',
+		'lag',
+		'trustCentralityScore',
+		'pageRankScore',
+		'trustRank',
+		'lastTrustCalculation'
 	],
 	definitions: {
 		NodeGeoDataV1: {

--- a/packages/shared/src/node.ts
+++ b/packages/shared/src/node.ts
@@ -36,6 +36,10 @@ export class Node {
 	public connectivityError = false;
 	public stellarCoreVersionBehind = false;
 	public lag: number | null = null;
+	public trustCentralityScore: number = 0;
+	public pageRankScore: number = 0;
+	public trustRank: number = 0;
+	public lastTrustCalculation: Date | null = null;
 
 	constructor(publicKey: string, ip = '127.0.0.1', port = 11625) {
 		this.ip = ip;
@@ -98,7 +102,11 @@ export class Node {
 			historyArchiveHasError: this.historyArchiveHasError,
 			connectivityError: this.connectivityError,
 			stellarCoreVersionBehind: this.stellarCoreVersionBehind,
-			lag: this.lag
+			lag: this.lag,
+			trustCentralityScore: this.trustCentralityScore,
+			pageRankScore: this.pageRankScore,
+			trustRank: this.trustRank,
+			lastTrustCalculation: this.lastTrustCalculation?.toISOString() || null
 		};
 	}
 
@@ -127,11 +135,16 @@ export class Node {
 			'quorumSet',
 			'statistics',
 			'dateDiscovered',
-			'dateUpdated'
+			'dateUpdated',
+			'lastTrustCalculation'
 		]);
 
 		node.dateDiscovered = new Date(nodeV1DTO.dateDiscovered);
 		node.dateUpdated = new Date(nodeV1DTO.dateUpdated);
+		
+		if (nodeV1DTO.lastTrustCalculation) {
+			node.lastTrustCalculation = new Date(nodeV1DTO.lastTrustCalculation);
+		}
 
 		return node;
 	}

--- a/terraform/environments/integration/main.tf
+++ b/terraform/environments/integration/main.tf
@@ -20,8 +20,8 @@ module "app_platform" {
   git_branch = "main"
 
   environment                    = "integration"
-  instance_size                  = "basic-xs"
-  history_scanner_instance_size  = "basic-s"
+  instance_size                  = "apps-s-1vcpu-1gb"
+  history_scanner_instance_size  = "apps-d-2vcpu-8gb"
 
   frontend_instance_count = 1
   backend_instance_count  = 1


### PR DESCRIPTION
This pull request introduces trust metrics to enhance the analysis of nodes in the network. Key changes include adding new trust-related fields to database models, implementing trust calculation algorithms, and integrating these metrics into the indexing and scanning processes.

### Database Changes
* Added new columns to the `node_snap_shot` and `node_measurement_v2` tables to store trust metrics (`trustCentralityScore`, `pageRankScore`, `trustRank`, and `lastTrustCalculation`), along with indexes for improved query performance. [[1]](diffhunk://#diff-6b539769f3cf430a78543a7e66e2ac42949657c0ed11acf5f2e09db766a59c65R1-R55) [[2]](diffhunk://#diff-7bd0df38747a5e285ccba7941899aa7194fe081d80fefbfe1345a4186ba1eac4R1-R39)
* Updated the precision of trust metric columns to `decimal(12,8)` to accommodate larger values.

### Domain Model Updates
* Added trust metric fields (`trustCentralityScore`, `pageRankScore`, `trustRank`, `lastTrustCalculation`) to the `NodeMeasurement` and `NodeSnapShot` classes to store calculated trust data. [[1]](diffhunk://#diff-13c7a36ab1b894923a5ecf6d2ba2db20ab67626f2b4eaa5426babd236476b9e6R49-R60) [[2]](diffhunk://#diff-a065b7d8c9e090bd7c1cc11c28f0e16e2a4dbe19f978c2b2b1d1698111ba912cR72-R83)
* Ensured trust metrics are copied when creating snapshots from nodes.

### Trust Calculation Logic
* Implemented the `TrustRankCalculator` class to calculate trust metrics using PageRank and organizational diversity.
* Added the `PageRankAlgorithm` class to compute PageRank scores, normalize them, and generate rankings.
* Defined interfaces and configurations for trust metrics (`TrustMetrics`, `PageRankConfiguration`, `NodeTrustData`, `TrustCalculationResult`).

### Integration with Scanning and Indexing
* Updated the `NodeScannerIndexerStep` to calculate trust metrics during node scanning and store them in the latest node measurement. [[1]](diffhunk://#diff-e30f947e706921cb642652807d640b8893bf675163cc6720635706c7c87bbe2fL1-R45) [[2]](diffhunk://#diff-e30f947e706921cb642652807d640b8893bf675163cc6720635706c7c87bbe2fR54-R69)
* Modified the `NodeIndexer` to incorporate pre-calculated trust metrics into node indexing logic. [[1]](diffhunk://#diff-30bc43fe1ec5dcb74bd5d898fb1664decaa58e8b0783492798b64873d5598e53R15) [[2]](diffhunk://#diff-30bc43fe1ec5dcb74bd5d898fb1664decaa58e8b0783492798b64873d5598e53L27-R31) [[3]](diffhunk://#diff-12ac561013fbbda958e6e593b4fbc7f1b41ad39f30988786ad800bd79f6abc62R17) [[4]](diffhunk://#diff-12ac561013fbbda958e6e593b4fbc7f1b41ad39f30988786ad800bd79f6abc62R29-R39)