### PR TITLE
change instance sizes

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -22,9 +22,9 @@ module "app_platform" {
   git_branch                = var.git_branch
   database_version_postgres = var.database_version_postgres
 
-  environment                    = "production"
-  instance_size                  = "apps-s-1vcpu-2gb"
-  history_scanner_instance_size  = "apps-d-4vcpu-16gb"
+  environment                   = "production"
+  instance_size                 = "apps-s-1vcpu-2gb"
+  history_scanner_instance_size = "apps-d-4vcpu-16gb"
 
   frontend_instance_count        = 2
   backend_instance_count         = 2
@@ -35,8 +35,8 @@ module "app_platform" {
   users_instance_count           = 1
 
   database_production = true
-  database_size       = "db-s-4vcpu-8gb"
-  database_node_count = 2
+  database_size       = "db-s-2vcpu-4gb"
+  database_node_count = 1
 
   feature_flags = {
     experimentalFeatures = false

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -263,6 +263,13 @@ variable "history_scanner_instance_count" {
   type        = number
   default     = 1
 }
+
+variable "history_scanner_instance_size" {
+  description = "Size of the history scanner instances"
+  type        = string
+  default     = "apps-d-2vcpu-8gb"
+}
+
 variable "users_instance_count" {
   description = "Number of instances for the users service"
   type        = number

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -27,14 +27,14 @@ module "app_platform" {
 
   frontend_instance_count        = 1
   backend_instance_count         = 1
-  testnet_backend_instance_count = 1
-  scanner_instance_count         = 1
+  testnet_backend_instance_count = 0
+  scanner_instance_count         = 0
   testnet_scanner_instance_count = 0
-  history_scanner_instance_count = 1
-  users_instance_count           = 1
+  history_scanner_instance_count = 0
+  users_instance_count           = 0
 
   database_production = false
-  database_size       = "db-s-2vcpu-4gb"
+
 
   feature_flags = {
     experimentalFeatures = false

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -372,6 +372,12 @@ variable "history_scan_api_password" {
   default     = "password"
 }
 
+variable "history_scanner_instance_size" {
+  description = "Size of the history scanner instances"
+  type        = string
+  default     = "apps-d-2vcpu-8gb"
+}
+
 variable "debug" {
   description = "Enable debug mode"
   type        = bool


### PR DESCRIPTION
This pull request updates the Terraform configuration for both the production and staging environments to reduce resource usage and costs. The main changes are reductions in database size and node count for production, and disabling several service instances in staging.

**Production environment resource adjustments:**

- Reduced the production database size from `"db-s-4vcpu-8gb"` to `"db-s-2vcpu-4gb"` and decreased the database node count from 2 to 1, lowering resource allocation and potential costs.

**Staging environment service scaling:**

- Set `testnet_backend_instance_count`, `scanner_instance_count`, `history_scanner_instance_count`, and `users_instance_count` to 0, effectively disabling these services in staging to minimize resource usage.
- Removed the explicit database size setting for staging, possibly reverting to a default or inherited value.