### PR TITLE
change db size

### DIFF
--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -33,7 +33,7 @@ module "app_platform" {
   history_scanner_instance_count = 0
   users_instance_count           = 0
 
-  database_production = false
+  database_production = true
 
 
   feature_flags = {


### PR DESCRIPTION
This pull request makes a configuration change to the `app_platform` module in the staging environment. The main change is enabling the use of the production database in staging.

Configuration update:

* Set `database_production` to `true` in `terraform/environments/staging/main.tf`, enabling the staging environment to use the production database.